### PR TITLE
py3k compatibility

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -20,10 +20,14 @@ from __future__ import (
 
 import re
 
-try:
-    from six import cStringIO as StringIO
-except ImportError:
-    from six import StringIO
+import six
+if six.PY2:
+    try:
+        from six import cStringIO as BufferIO
+    except ImportError:
+        from six import StringIO as BufferIO
+else:
+    from io import BytesIO as BufferIO
 
 from functools import wraps
 from requests.adapters import HTTPAdapter
@@ -112,7 +116,7 @@ class RequestsMock(object):
 
         response = HTTPResponse(
             status=match['status'],
-            body=StringIO(match['body']),
+            body=BufferIO(match['body']),
             headers=headers,
             preload_content=False,
         )

--- a/test_responses.py
+++ b/test_responses.py
@@ -18,7 +18,7 @@ def assert_response(resp, body=None):
 def test_response():
     @responses.activate
     def run():
-        responses.add(responses.GET, 'http://example.com', body=str('test'))
+        responses.add(responses.GET, 'http://example.com', body=b'test')
         resp = requests.get('http://example.com')
         assert_response(resp, 'test')
 
@@ -50,7 +50,7 @@ def test_match_querystring():
         url = 'http://example.com?test=1'
         responses.add(
             responses.GET, url,
-            match_querystring=True, body=str('test'))
+            match_querystring=True, body=b'test')
         resp = requests.get(url)
         assert_response(resp, 'test')
 


### PR DESCRIPTION
- Bodies actually as bytes in test suite
- use StringIO or BytesIO depending on python version :(
