### PR TITLE
Play nicely with installations that do not bundle urllib3

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -33,7 +33,10 @@ from collections import namedtuple, Sequence, Sized
 from functools import wraps
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
-from requests.packages.urllib3.response import HTTPResponse
+try:
+    from requests.packages.urllib3.response import HTTPResponse
+except ImportError:
+    from urllib3.response import HTTPResponse
 
 Call = namedtuple('Call', ['request', 'response'])
 


### PR DESCRIPTION
Debian removes the urllib3 library from requests. This patch allows responses to work with Debian's python-requests package. Relevant Debian patch removing urllib3: 

http://anonscm.debian.org/viewvc/python-modules/packages/requests/trunk/debian/patches/02_use-system-chardet-and-urllib3.patch?revision=27448&view=markup
