### PR TITLE
Add space to get rid of e265 and pass travis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ class PyTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import pytest
         errno = pytest.main(self.test_args)
         sys.exit(errno)


### PR DESCRIPTION
Nobody likes being the last commit with a failing travis build. Add a space in a comment, quick win. 
