### PR TITLE
Added one_shot option

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -80,7 +80,7 @@ class RequestsMock(object):
 
     def add(self, method, url, body='', match_querystring=False,
             status=200, adding_headers=None, stream=False,
-            content_type='text/plain'):
+            content_type='text/plain', one_shot=False):
         # ensure the url has a default path set
         if url.count('/') == 2:
             url = url.replace('?', '/?', 1) if match_querystring \
@@ -99,6 +99,7 @@ class RequestsMock(object):
             'status': status,
             'adding_headers': adding_headers,
             'stream': stream,
+            'one_shot': one_shot,
         })
 
     @property
@@ -120,7 +121,7 @@ class RequestsMock(object):
         url = request.url
         url_without_qs = url.split('?', 1)[0]
 
-        for match in self._urls:
+        for i, match in enumerate(self._urls):
             if request.method != match['method']:
                 continue
 
@@ -133,6 +134,8 @@ class RequestsMock(object):
                 if match['url'] != url_without_qs:
                     continue
 
+            if match['one_shot']:
+                del self._urls[i]
             return match
 
         return None

--- a/test_responses.py
+++ b/test_responses.py
@@ -89,3 +89,24 @@ def test_accept_string_body():
 
     run()
     assert_reset()
+
+
+def test_one_shot():
+    @responses.activate
+    def run():
+        responses.add(
+            responses.GET, 'http://example.com',
+            body=b'test', one_shot=True)
+
+        resp = requests.get('http://example.com')
+        assert_response(resp, 'test')
+
+        with pytest.raises(ConnectionError):
+            requests.get('http://example.com')
+
+        assert len(responses.calls) == 2
+        assert responses.calls[0].response.content == b'test'
+        assert type(responses.calls[1].response) is ConnectionError
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Hi!

First of all, thanks for sharing this great library :)

I added option 'one_shot' which removes response object from _urls after first call.

With this option, you can test functions that makes several requests to one URL. For example, it can be function that checks given URL until any data becomes available, or functions with some complex error handling ("if remote API says it is busy, wait and make one more request").
