### PR TITLE
Create `add_json` shortcut method.

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -30,6 +30,7 @@ else:
 
 from collections import namedtuple, Sequence, Sized
 from functools import wraps
+import json
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
 try:
@@ -104,6 +105,17 @@ class RequestsMock(object):
             'adding_headers': adding_headers,
             'stream': stream,
         })
+
+    def add_json(self, method, url, body=None, match_querystring=False,
+                 status=200, adding_headers=None, stream=False):
+        """
+        Adds a JSON response. It's the same as calling `responses.add`
+        assuming that `body` is a dict and content_type is `application/json`.
+        """
+        body = json.dumps(body or {})
+        self.add(method, url, body=body, match_querystring=match_querystring,
+                 status=status, adding_headers=adding_headers, stream=stream,
+                 content_type='application/json')
 
     @property
     def calls(self):

--- a/test_responses.py
+++ b/test_responses.py
@@ -5,6 +5,7 @@ from __future__ import (
 import requests
 import responses
 import pytest
+import json
 
 from requests.exceptions import ConnectionError
 
@@ -14,9 +15,9 @@ def assert_reset():
     assert len(responses.calls) == 0
 
 
-def assert_response(resp, body=None):
+def assert_response(resp, body=None, content_type='text/plain'):
     assert resp.status_code == 200
-    assert resp.headers['Content-Type'] == 'text/plain'
+    assert resp.headers['Content-Type'] == content_type
     assert resp.text == body
 
 
@@ -91,3 +92,17 @@ def test_accept_string_body():
 
     run()
     assert_reset()
+
+
+def test_add_json():
+    @responses.activate
+    def run():
+        url = 'http://example.com/'
+        body = {'some-key': 'a-value'}
+        responses.add_json(responses.GET, url, body=body)
+        resp = requests.get(url)
+        assert_response(resp, json.dumps(body), content_type='application/json')
+
+    run()
+    assert_reset()
+

--- a/test_responses.py
+++ b/test_responses.py
@@ -101,8 +101,8 @@ def test_add_json():
         body = {'some-key': 'a-value'}
         responses.add_json(responses.GET, url, body=body)
         resp = requests.get(url)
-        assert_response(resp, json.dumps(body), content_type='application/json')
+        assert_response(resp, json.dumps(body),
+                        content_type='application/json')
 
     run()
     assert_reset()
-

--- a/test_responses.py
+++ b/test_responses.py
@@ -1,11 +1,11 @@
 from __future__ import (
     absolute_import, print_function, division, unicode_literals
 )
+import json
 
 import requests
 import responses
 import pytest
-import json
 
 from requests.exceptions import ConnectionError
 


### PR DESCRIPTION
Same as calling `responses.add` assuming that the body is
a dict and the content type is application/json.
