### PR TITLE
Remove unnecessary unicode conversion in callbacks

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -189,6 +189,8 @@ class RequestsMock(object):
 
         if 'callback' in match:  # use callback
             status, r_headers, body = match['callback'](request)
+            if isinstance(body, six.text_type):
+                body = body.encode('utf-8')
             body = BufferIO(body)
             headers.update(r_headers)
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -162,7 +162,7 @@ def test_callback():
     def run():
         responses.add_callback(responses.GET, url, request_callback)
         resp = requests.get(url)
-        assert resp.text == body
+        assert resp.text == "test callback"
         assert resp.status_code == status
         assert 'foo' in resp.headers
         assert resp.headers['foo'] == 'bar'


### PR DESCRIPTION
This doesn't seem to fit with the rest of the module and limits what can be supplied as a body!
