### PR TITLE
allow to use responses as context manager

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -121,15 +121,18 @@ class RequestsMock(object):
     def calls(self):
         return self._calls
 
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, *args):
+        self.stop()
+        self.reset()
+
     def activate(self, func):
         @wraps(func)
         def wrapped(*args, **kwargs):
-            self.start()
-            try:
+            with self:
                 return func(*args, **kwargs)
-            finally:
-                self.stop()
-                self.reset()
         return wrapped
 
     def _find_match(self, request):
@@ -228,7 +231,7 @@ class RequestsMock(object):
 
 
 # expose default mock namespace
-_default_mock = RequestsMock()
+mock = _default_mock = RequestsMock()
 __all__ = []
 for __attr in (a for a in dir(_default_mock) if not a.startswith('_')):
     __all__.append(__attr)

--- a/test_responses.py
+++ b/test_responses.py
@@ -218,3 +218,24 @@ def test_custom_adapter():
         assert_response(resp, 'test')
 
     run()
+
+
+def test_responses_as_context_manager():
+    def run():
+        with responses.mock:
+            responses.add(responses.GET, 'http://example.com', body=b'test')
+            resp = requests.get('http://example.com')
+            assert_response(resp, 'test')
+            assert len(responses.calls) == 1
+            assert responses.calls[0].request.url == 'http://example.com/'
+            assert responses.calls[0].response.content == b'test'
+
+            resp = requests.get('http://example.com?foo=bar')
+            assert_response(resp, 'test')
+            assert len(responses.calls) == 2
+            assert (responses.calls[1].request.url ==
+                    'http://example.com/?foo=bar')
+            assert responses.calls[1].response.content == b'test'
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Hi,
This feature is useful for me, because I only want to catch a subset of my requests calls.
In other word, I still want (for legacy reason) to perform requests calls for real in the context of my test method.

I used `context.mock` but I'm open of better suggestion for the name of the context manager.
