### PR TITLE
Add feature to bypass responses per demand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,22 @@ A response can also throw an exception as follows.
     # All calls to 'http://twitter.com/api/1/foobar' will throw exception.
 
 
+Allow responses to perform real http-request
+--------------------------------------------
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+
+    @responses.activate
+    def test_my_api():
+        responses.allow(responses.GET, 'https://twitter.com/api/1/foobar')
+        response = requests.get('https://twitter.com/api/1/foobar')
+        assert response.status_code == 404
+
+
 Responses as a context manager
 ------------------------------
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -2,10 +2,12 @@ from __future__ import (
     absolute_import, print_function, division, unicode_literals
 )
 
+import random
 import re
 import requests
 import responses
 import pytest
+import string
 
 from inspect import getargspec
 from requests.exceptions import ConnectionError, HTTPError
@@ -366,6 +368,25 @@ def test_allow_redirects_samehost():
             status_codes = [call[1].status_code for call in responses.calls]
             assert status_codes == [301, 301, 200]
         assert_reset()
+
+
+def test_allow_feature(monkeypatch):
+
+    @responses.activate
+    def run():
+        called = []
+
+        def capture_all(self, request, *args, **kw):
+            called.append(request)
+
+        monkeypatch.setattr(requests.Session, 'send', capture_all)
+
+        # hopefully this domain name doesn't exists
+        fake_url = 'http://{0}.com/'.format(''.join(
+            random.choice(string.digits) for i in range(60)))
+        responses.allow(responses.GET, fake_url)
+        requests.get(fake_url)
+        assert called[0].url == fake_url
 
     run()
     assert_reset()


### PR DESCRIPTION
This one is probably controversial.
`bypass` allows to bypass responses for selected requests.
Since `requests` is used in many libraries including elasticsearch clients for instance.
I would like in my test to *NOT* capture those calls in the context of `@responses.activate` that I'm using to capture calls to the web in the mean time.

Yep, I'm testing spaghetti code.