### PR TITLE
Simplify `get_wrapped` function

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -56,14 +56,12 @@ def get_wrapped(func, wrapper_template, evaldict):
     # Preserve the argspec for the wrapped function so that testing
     # tools such as pytest can continue to use their fixture injection.
     args, a, kw, defaults = inspect.getargspec(func)
-    values = args[-len(defaults):] if defaults else None
 
     signature = inspect.formatargspec(args, a, kw, defaults)
     is_bound_method = hasattr(func, '__self__')
     if is_bound_method:
         args = args[1:]     # Omit 'self'
-    callargs = inspect.formatargspec(args, a, kw, values,
-                                     formatvalue=lambda v: '=' + v)
+    callargs = inspect.formatargspec(args, a, kw, None)
 
     ctx = {'signature': signature, 'funcargs': callargs}
     six.exec_(wrapper_template % ctx, evaldict)


### PR DESCRIPTION
I noticed that the keyword arguments can be passed by position instead of passing them by keyword.
It simplifies sligthly the function.