### PR TITLE
Fix example with context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ Responses as a context manager
 
 
     def test_my_api():
-        with responses.RequestsMock() as rsps:
-            rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
+        with responses.mock:
+            responses.add(responses.GET, 'http://twitter.com/api/1/foobar',
                      body='{}', status=200,
                      content_type='application/json')
             resp = requests.get('http://twitter.com/api/1/foobar')
@@ -125,7 +125,7 @@ Responses as a context manager
 
         # outside the context manager requests will hit the remote server
         resp = requests.get('http://twitter.com/api/1/foobar')
-        resp.status_code == 404
+        assert resp.status_code == 404
 
 
 Assertions on declared responses


### PR DESCRIPTION
The example showing how to use responses as a context manager does not work:
```Python
In [1]: %paste
import responses
import requests

def test_my_api():
    with responses.RequestsMock() as rsps:
        rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
                 body='{}', status=200,
                 content_type='application/json')
        resp = requests.get('http://twitter.com/api/1/foobar')

        assert resp.status_code == 200

    # outside the context manager requests will hit the remote server
    resp = requests.get('http://twitter.com/api/1/foobar')
    assert resp.status_code == 404
In [2]: test_my_api()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-4135ff75b683> in <module>()
----> 1 test_my_api()

<ipython-input-1-3b41032991c0> in test_my_api()
      5 def test_my_api():
      6     with responses.RequestsMock() as rsps:
----> 7         rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
      8                  body='{}', status=200,
      9                  content_type='application/json')

AttributeError: 'NoneType' object has no attribute 'add'

```
I checked the tests for that and tests are using another approach, aligning those two with this PR