### PR TITLE
Fix ConnectionError Emulation

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -225,7 +225,8 @@ class RequestsMock(object):
         if match is None:
             error_msg = 'Connection refused: {0} {1}'.format(request.method,
                                                              request.url)
-            response = ConnectionError(error_msg, request=request)
+            response = ConnectionError(error_msg)
+            response.request = request
 
             self._calls.add(request, response)
             raise response

--- a/responses.py
+++ b/responses.py
@@ -225,7 +225,7 @@ class RequestsMock(object):
         if match is None:
             error_msg = 'Connection refused: {0} {1}'.format(request.method,
                                                              request.url)
-            response = ConnectionError(error_msg)
+            response = ConnectionError(error_msg, request=request)
 
             self._calls.add(request, response)
             raise response

--- a/test_responses.py
+++ b/test_responses.py
@@ -53,6 +53,7 @@ def test_connection_error():
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == 'http://example.com/foo'
         assert type(responses.calls[0].response) is ConnectionError
+        assert responses.calls[0].response.request
 
     run()
     assert_reset()


### PR DESCRIPTION
When raising a ConnectionError, the requests module sets the error's request attribute to the current request. The responses module should do the same.

Sample Script:
```
import requests
import responses

def req():
    try:
        requests.get('http://example.zalando.net')
    except Exception as e:
        return(e.request)
    else:
        assert False

print('Real:          ', req())
print('With responses:', responses.activate(req)())
```

Output:
```
Real:           <PreparedRequest [GET]>
With responses: None
````