### PR TITLE
ENH: don't add default path if scheme is not http(s).

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -101,11 +101,13 @@ class CallList(Sequence, Sized):
 
 
 def _ensure_url_default_path(url, match_querystring):
-    if _is_string(url) and url.count('/') == 2:
-        if match_querystring:
-            return url.replace('?', '/?', 1)
-        else:
-            return url + '/'
+    if _is_string(url):
+        p = urlparse(url)
+        if p.scheme in ("http", "https") and url.count('/') == 2:
+            if match_querystring:
+                return url.replace('?', '/?', 1)
+            else:
+                return url + '/'
     return url
 
 


### PR DESCRIPTION
Responses 0.4.0 and above change urls of the type "file://foo.bar" into "file://foo.bar/" for mocked urls. I don't think that's right.

This is a naive patch working around this, but I was not sure why http urls were changed to have a default path.
