### PR TITLE
Allow passing a JSON body to `responses.add`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,26 @@ Response body as string
         assert responses.calls[0].request.url == 'http://twitter.com/api/1/foobar'
         assert responses.calls[0].response.text == '{"error": "not found"}'
 
+You can also specify a JSON object instead of a body string.
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+    @responses.activate
+    def test_my_api():
+        responses.add(responses.GET, 'http://twitter.com/api/1/foobar',
+                      json={"error": "not found"}, status=404)
+
+        resp = requests.get('http://twitter.com/api/1/foobar')
+
+        assert resp.json() == {"error": "not found"}
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://twitter.com/api/1/foobar'
+        assert responses.calls[0].response.text == '{"error": "not found"}'
+
 Request callback
 ----------------
 

--- a/responses.py
+++ b/responses.py
@@ -132,7 +132,8 @@ class RequestsMock(object):
             status=200, adding_headers=None, stream=False,
             content_type='text/plain', json=None):
 
-        # if we were passed a `json` argument, override the body and content_type
+        # if we were passed a `json` argument,
+        # override the body and content_type
         if json:
             body = json_module.dumps(json)
             content_type = 'application/json'

--- a/responses.py
+++ b/responses.py
@@ -3,6 +3,7 @@ from __future__ import (
 )
 
 import inspect
+import json as json_module
 import re
 import six
 
@@ -129,7 +130,12 @@ class RequestsMock(object):
 
     def add(self, method, url, body='', match_querystring=False,
             status=200, adding_headers=None, stream=False,
-            content_type='text/plain'):
+            content_type='text/plain', json=None):
+
+        # if we were passed a `json` argument, override the body and content_type
+        if json:
+            body = json_module.dumps(json)
+            content_type = 'application/json'
 
         # ensure the url has a default path set if the url is a string
         url = _ensure_url_default_path(url, match_querystring)

--- a/test_responses.py
+++ b/test_responses.py
@@ -150,6 +150,21 @@ def test_accept_string_body():
     assert_reset()
 
 
+def test_accept_json_body():
+    @responses.activate
+    def run():
+        url = 'http://example.com/'
+        responses.add(
+            responses.GET, url, json={"message": "success"})
+        resp = requests.get(url)
+        assert resp.status_code == 200
+        assert resp.headers['Content-Type'] == 'application/json'
+        assert resp.text == '{"message": "success"}'
+
+    run()
+    assert_reset()
+
+
 def test_throw_connection_error_explicit():
     @responses.activate
     def run():


### PR DESCRIPTION
It's a lot more convenient than writing a JSON-formatted string, and it automatically sets the Content-Type header for you!