### PR TITLE
Don't swallow exceptions

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -304,11 +304,16 @@ class RequestsMock(object):
             assertion_error = AssertionError(
                 'Not all requests have been executed {0!r}'.format(
                     [(url['method'], url['url']) for url in self._urls]))
-            if self.captured_exception:
+            if self.captured_exception[0]:
                 try:
                     six.reraise(*self.captured_exception)
                 except Exception as raise_from:
-                    six.raise_from(assertion_error, raise_from)
+                    if six.PY2:
+                        # Python2 doesn't support exceptions chaining, so 
+                        # we'll just re-raise the original exception
+                        raise
+                    else:
+                        six.raise_from(assertion_error, raise_from)
             raise assertion_error
 
 

--- a/responses.py
+++ b/responses.py
@@ -305,15 +305,7 @@ class RequestsMock(object):
                 'Not all requests have been executed {0!r}'.format(
                     [(url['method'], url['url']) for url in self._urls]))
             if self.captured_exception[0]:
-                try:
-                    six.reraise(*self.captured_exception)
-                except Exception as raise_from:
-                    if six.PY2:
-                        # Python2 doesn't support exceptions chaining, so 
-                        # we'll just re-raise the original exception
-                        raise
-                    else:
-                        six.raise_from(assertion_error, raise_from)
+                six.reraise(*self.captured_exception)
             raise assertion_error
 
 

--- a/responses.py
+++ b/responses.py
@@ -304,9 +304,11 @@ class RequestsMock(object):
             if self.captured_exception[0]:
                 six.reraise(*self.captured_exception)
             else:
-                raise AssertionError('Not all requests have been executed {0!r}'.format(
-                    [(url['method'], url['url']) for url in self._urls]
-                ))
+                raise AssertionError(
+                    'Not all requests have been executed {0!r}'.format(
+                        [(url['method'], url['url']) for url in self._urls]
+                    )
+                )
 
 
 # expose default mock namespace

--- a/responses.py
+++ b/responses.py
@@ -301,12 +301,12 @@ class RequestsMock(object):
     def stop(self):
         self._patcher.stop()
         if self.assert_all_requests_are_fired and self._urls:
-            assertion_error = AssertionError(
-                'Not all requests have been executed {0!r}'.format(
-                    [(url['method'], url['url']) for url in self._urls]))
             if self.captured_exception[0]:
                 six.reraise(*self.captured_exception)
-            raise assertion_error
+            else:
+                raise AssertionError('Not all requests have been executed {0!r}'.format(
+                    [(url['method'], url['url']) for url in self._urls]
+                ))
 
 
 # expose default mock namespace

--- a/test_responses.py
+++ b/test_responses.py
@@ -350,19 +350,24 @@ def test_assert_all_requests_are_fired_does_not_shadow_exceptions():
                 m.add(responses.GET, 'http://example.com', body=b'test')
                 raise ValueError('foo')
             assert "raise ValueError('foo')" in ''.join(
-            traceback.format_tb(excinfo.tb))
+                traceback.format_tb(excinfo.tb)
+            )
 
     run()
     assert_reset()
 
+
 def test_assert_context_manager_does_not_shadow_exceptions():
     def run():
         with pytest.raises(ValueError) as excinfo:
-            with responses.RequestsMock(assert_all_requests_are_fired=False) as m:
+            with responses.RequestsMock(
+                assert_all_requests_are_fired=False
+            ) as m:
                 m.add(responses.GET, 'http://example.com', body=b'test')
                 raise ValueError('foo')
             assert "raise ValueError('foo')" in ''.join(
-            traceback.format_tb(excinfo.tb))
+                traceback.format_tb(excinfo.tb)
+            )
     run()
     assert_reset()
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -7,7 +7,6 @@ import re
 import requests
 import responses
 import pytest
-import six
 
 from inspect import getargspec
 from requests.exceptions import ConnectionError, HTTPError

--- a/test_responses.py
+++ b/test_responses.py
@@ -355,6 +355,17 @@ def test_assert_all_requests_are_fired_does_not_shadow_exceptions():
     run()
     assert_reset()
 
+def test_assert_context_manager_does_not_shadow_exceptions():
+    def run():
+        with pytest.raises(ValueError) as excinfo:
+            with responses.RequestsMock(assert_all_requests_are_fired=False) as m:
+                m.add(responses.GET, 'http://example.com', body=b'test')
+                raise ValueError('foo')
+            assert "raise ValueError('foo')" in ''.join(
+            traceback.format_tb(excinfo.tb))
+    run()
+    assert_reset()
+
 
 def test_allow_redirects_samehost():
     redirecting_url = 'http://example.com'

--- a/test_responses.py
+++ b/test_responses.py
@@ -345,26 +345,13 @@ def test_assert_all_requests_are_fired():
 
 def test_assert_all_requests_are_fired_does_not_shadow_exceptions():
     def run():
-        if six.PY2:
-            # Python 2 doesn't support exceptions chaining, so in that case 
-            # just the original ValueError exception should be raised
-            with pytest.raises(ValueError) as excinfo:
-                with responses.RequestsMock(
-                        assert_all_requests_are_fired=True) as m:
-                    m.add(responses.GET, 'http://example.com', body=b'test')
-                    raise ValueError('foo')
-                assert "raise ValueError('foo')" in ''.join(
-                traceback.format_tb(excinfo.tb))
-        else:
-            with pytest.raises(AssertionError) as excinfo:
-                with responses.RequestsMock(
-                        assert_all_requests_are_fired=True) as m:
-                    m.add(responses.GET, 'http://example.com', body=b'test')
-                    raise ValueError('foo')
-            assert 'http://example.com' in str(excinfo.value)
-            assert responses.GET in str(excinfo)
+        with pytest.raises(ValueError) as excinfo:
+            with responses.RequestsMock(
+                    assert_all_requests_are_fired=True) as m:
+                m.add(responses.GET, 'http://example.com', body=b'test')
+                raise ValueError('foo')
             assert "raise ValueError('foo')" in ''.join(
-                traceback.format_tb(excinfo.tb))
+            traceback.format_tb(excinfo.tb))
 
     run()
     assert_reset()


### PR DESCRIPTION
Currently, if an exceptions occurs within a RequestsMock with-block, it gets swallowed by the context manager. This fix makes the context manager instead re-raise the original exception.

These changes are based on #55. However, instead of chaining the exception with any assertion error due to all requests not being fired, I just re-raised the original exception since I think that makes more sense. However, if you prefer the exception-chaining behaviour, the tree at 4c00da8c4daab5d328a9b730433393971ac2a15e should do the work (#55 does still swallow exceptions on python 2 where exception chaining doesn't exist).

This should also fix #72.
