### PR TITLE
Allow external requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,3 +165,30 @@ can be disabled by passing the ``assert_all_requests_are_fired`` value:
             rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
                      body='{}', status=200,
                      content_type='application/json')
+
+
+Allowing non mocked requests
+--------------------------------
+
+By default Responses will raise an exception if an url not mocked is called. This behavior can
+be changed by passing the ``allow_external_requests`` value:
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+
+    def test_my_api():
+        with responses.RequestsMock(allow_external_requests=True) as rsps:
+            rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
+                     body='{}', status=200,
+                     content_type='application/json')
+
+            # use the mocked route
+            resp = requests.get('http://twitter.com/api/1/foobar')
+            assert resp.status_code == 200
+
+            # will hit the remote server
+            resp = requests.get('http//twitter.com/')
+            assert resp.status_code == 200

--- a/responses.py
+++ b/responses.py
@@ -119,10 +119,12 @@ class RequestsMock(object):
     POST = 'POST'
     PUT = 'PUT'
 
-    def __init__(self, assert_all_requests_are_fired=True):
+    def __init__(self, assert_all_requests_are_fired=True,
+                 allow_external_requests=False):
         self._calls = CallList()
         self.reset()
         self.assert_all_requests_are_fired = assert_all_requests_are_fired
+        self.allow_external_requests = allow_external_requests
 
     def reset(self):
         self._urls = []
@@ -230,6 +232,9 @@ class RequestsMock(object):
         match = self._find_match(request)
         # TODO(dcramer): find the correct class for this
         if match is None:
+            if self.allow_external_requests:
+                return self._patcher.temp_original(adapter, request, **kwargs)
+
             error_msg = 'Connection refused: {0} {1}'.format(request.method,
                                                              request.url)
             response = ConnectionError(error_msg)

--- a/test_responses.py
+++ b/test_responses.py
@@ -385,3 +385,30 @@ def test_allow_redirects_samehost():
 
     run()
     assert_reset()
+
+
+def test_allow_external_requests():
+    def run():
+        with responses.RequestsMock(
+                allow_external_requests=False) as m:
+            m.add(responses.GET, 'http://example.com', body=b'test')
+
+            resp = requests.get('http://example.com')
+            assert resp.content == b'test'
+
+            with pytest.raises(ConnectionError):
+                requests.get('http://google.com')
+
+        with responses.RequestsMock(
+                allow_external_requests=True) as m:
+            m.add(responses.GET, 'http://example.com', body=b'test')
+
+            resp = requests.get('http://example.com')
+            assert resp.content == b'test'
+
+            # needs an active connection
+            resp = requests.get('http://google.com')
+            assert resp.status_code == 200
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Sometimes,you want to mock a specific service, but you still want to be able to reach other services. With this PR, if `allow_external_requests` is `True`, calls to non mocked urls don't throw `ConnectionError`.

This is somewhat similar to #39.

EDIT: If someone is interested by this behavior, note that change may never be included in responses, as per @dcramer's [comment](https://github.com/getsentry/responses/pull/39#issuecomment-166695026) in #39.
If you need a way to mock an API while being able to make external requests, [request-mock](https://requests-mock.readthedocs.org/en/latest/) seems to be a good option.
