### PR TITLE
Add multi-response support

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -119,11 +119,11 @@ class RequestsMock(object):
     POST = 'POST'
     PUT = 'PUT'
 
-    def __init__(self, multi_response=True, assert_all_requests_are_fired=True):
+    def __init__(self, multi_response=False, assert_all_requests_are_fired=True):
         self._calls = CallList()
         self.reset()
-        self.assert_all_requests_are_fired = multi_response
-        self.multi_response = multi_response
+        self.assert_all_requests_are_fired = assert_all_requests_are_fired
+        self.multi_response = assert_all_requests_are_fired or multi_response
 
     def reset(self):
         self._urls = []

--- a/responses.py
+++ b/responses.py
@@ -119,7 +119,11 @@ class RequestsMock(object):
     POST = 'POST'
     PUT = 'PUT'
 
-    def __init__(self, multi_response=False, assert_all_requests_are_fired=True):
+    def __init__(
+        self,
+        multi_response=False,
+        assert_all_requests_are_fired=True
+    ):
         self._calls = CallList()
         self.reset()
         self.assert_all_requests_are_fired = assert_all_requests_are_fired

--- a/responses.py
+++ b/responses.py
@@ -119,10 +119,11 @@ class RequestsMock(object):
     POST = 'POST'
     PUT = 'PUT'
 
-    def __init__(self, assert_all_requests_are_fired=True):
+    def __init__(self, multi_response=True, assert_all_requests_are_fired=True):
         self._calls = CallList()
         self.reset()
-        self.assert_all_requests_are_fired = assert_all_requests_are_fired
+        self.assert_all_requests_are_fired = multi_response
+        self.multi_response = multi_response
 
     def reset(self):
         self._urls = []
@@ -196,9 +197,6 @@ class RequestsMock(object):
             break
         else:
             return None
-        if self.assert_all_requests_are_fired:
-            # for each found match remove the url from the stack
-            self._urls.remove(match)
         return match
 
     def _has_url_match(self, match, request_url):
@@ -237,6 +235,9 @@ class RequestsMock(object):
 
             self._calls.add(request, response)
             raise response
+        elif self.multi_response:
+            # for each found match remove the url from the stack
+            self._urls.remove(match)
 
         if 'body' in match and isinstance(match['body'], Exception):
             self._calls.add(request, match['body'])
@@ -305,7 +306,10 @@ class RequestsMock(object):
 
 
 # expose default mock namespace
-mock = _default_mock = RequestsMock(assert_all_requests_are_fired=False)
+mock = _default_mock = RequestsMock(
+    multi_response=False,
+    assert_all_requests_are_fired=False,
+)
 __all__ = []
 for __attr in (a for a in dir(_default_mock) if not a.startswith('_')):
     __all__.append(__attr)


### PR DESCRIPTION
I often find myself needing to test something like the following:

`Test that if a response fails the first time, my code is able to retry the request a certain amount of times before giving up.`

Currently (as far as I could tell from the documentation and reading the code at first glance) this didnt seen possible and I usually resorted to using mock instead.

Here is a (very simplified) example of a test I have written before to test a scenario where my code should retry once before giving up.

```
    @mock.patch('requests')
    def test_retry_on_error(self, requests):
        response = mock.Mock()
        requests.get.return_value = response
        response.iter_lines.side_effect = [requests_exceptions.HTTPError(), []]
        my_requesting_code()
```

It would be more ideal to use responses because that's more readable.

While trying to add this feature to the responses library I noticed that you are essentially already supporting this use case through the `assert_all_requests_are_fired` option which removes urls from `self._urls` as they are used. 

However this is very non-obvious and required me to actually delve into the code to figure this out!

This pull request therefore adds a more obvious "multi_response" flag as a parameter which essentially enables the same functionality but without asserting all responses were fired at the end. 

I wrote a test for the multi response case and updated `test_assert_all_requests_are_fired` to ensure the code still works as expected.

I'm open to updating the code as you see fit as I understand the way I use the constructor parameters is a bit hacky but I think a feature like this could be very valuable for users.
