### PR TITLE
Update changelog for changes since 0.5.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.5.1
+-----
+
+- Add LICENSE, README and CHANGES to the PyPI distribution (GH-97).
+
 0.5.0
 -----
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+- Allow empty list/dict as json object (GH-100)
+
 0.5.1
 -----
 


### PR DESCRIPTION
I was using requires.io to bring our dependencies up to date, and in so doing I noticed that the changelog for responses hasn't been updated for the 0.5.1 release.

Looking at the diffs shows that the only user-facing change was to packaging:
https://github.com/getsentry/responses/compare/0.5.0...0.5.1

However it makes sense to update CHANGES to save others having to audit this by hand too :-)

I've also noted changes on master, since it will make it quicker to release the next version, if the changelog is already up to date:
https://github.com/getsentry/responses/compare/0.5.1...c62fd372fff0bd77335bb0e7a0569aa056226521