### PR TITLE
support for providing query params as a dict in responses.add

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,29 @@ You can also specify a JSON object instead of a body string.
         assert responses.calls[0].request.url == 'http://twitter.com/api/1/foobar'
         assert responses.calls[0].response.text == '{"error": "not found"}'
 
+Expected query params can be provided as a dict and verified in the call:
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+    @responses.activate
+    def test_my_api():
+        query_params = {"test": 2, "foo": "baz", "name": ["boaty", "mcboatface"]}
+        responses.add(responses.GET, 'http://twitter.com/api/1/foobar',
+                      json={"error": "not found"}, status=404,
+                      match_querystring=True, query_params=query_params)
+
+        resp = requests.get('http://twitter.com/api/1/foobar', params=query_params)
+
+        assert resp.json() == {"error": "not found"}
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://twitter.com/api/1/foobar?test=2&foo=baz&name=boaty&name=mcboatface'
+        assert responses.calls[0].response.text == '{"error": "not found"}'
+
+
 Request callback
 ----------------
 

--- a/responses.py
+++ b/responses.py
@@ -300,7 +300,8 @@ class RequestsMock(object):
                 if v is not None:
                     result.append(
                         (k.encode('utf-8') if isinstance(k, str) else k,
-                        v.encode('utf-8') if isinstance(v, str) else v))
+                            v.encode('utf-8') if isinstance(v, str) else v)
+                    )
         return urlencode(result, doseq=True)
 
     def start(self):

--- a/responses.py
+++ b/responses.py
@@ -142,8 +142,8 @@ class RequestsMock(object):
         # if we are passed a query_params dict, create the query
         # string and append to the url
         if query_params:
-          query_string = self._build_query(query_params)
-          url = "{0}?{1}".format(url, query_string)
+            query_string = self._build_query(query_params)
+            url = "{0}?{1}".format(url, query_string)
 
         # ensure the url has a default path set if the url is a string
         url = _ensure_url_default_path(url, match_querystring)
@@ -292,16 +292,16 @@ class RequestsMock(object):
         return response
 
     def _build_query(self, query_params):
-      result = []
-      for k, vs in query_params.iteritems():
-        if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
-          vs = [vs]
-        for v in vs:
-          if v is not None:
-            result.append(
-              (k.encode('utf-8') if isinstance(k, str) else k,
-              v.encode('utf-8') if isinstance(v, str) else v))
-      return urlencode(result, doseq=True)
+        result = []
+        for k, vs in query_params.iteritems():
+            if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
+                vs = [vs]
+            for v in vs:
+                if v is not None:
+                    result.append(
+                        (k.encode('utf-8') if isinstance(k, str) else k,
+                        v.encode('utf-8') if isinstance(v, str) else v))
+        return urlencode(result, doseq=True)
 
     def start(self):
         try:

--- a/responses.py
+++ b/responses.py
@@ -10,7 +10,7 @@ import six
 from collections import namedtuple, Sequence, Sized
 from functools import update_wrapper
 from cookies import Cookies
-from requests.utils import cookiejar_from_dict
+from requests.utils import cookiejar_from_dict, to_key_val_list
 from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
 from requests.compat import urlencode, basestring
@@ -293,7 +293,7 @@ class RequestsMock(object):
 
     def _build_query(self, query_params):
         result = []
-        for k, vs in query_params.iteritems():
+        for k, vs in to_key_val_list(query_params):
             if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
                 vs = [vs]
             for v in vs:

--- a/responses.py
+++ b/responses.py
@@ -13,7 +13,7 @@ from cookies import Cookies
 from requests.utils import cookiejar_from_dict
 from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
-from requests.compat import urlencode
+from requests.compat import urlencode, basestring
 
 try:
     from requests.packages.urllib3.response import HTTPResponse

--- a/test_responses.py
+++ b/test_responses.py
@@ -79,15 +79,19 @@ def test_match_querystring_with_params():
     @responses.activate
     def run():
         url = 'http://example.com'
-        query_params = {"test": 2, "foo": "baz",
-            "name": ["boaty", "mcboatface"]}
+        query_params = {
+            "test": 2, "foo": "baz",
+            "name": ["boaty", "mcboatface"]
+        }
         responses.add(
             responses.GET, url,
             match_querystring=True, query_params=query_params,
             body=b'test')
-        resp = requests.get('http://example.com?test=2&foo=baz&name=boaty&name=mcboatface')
+        resp = requests.get(
+            'http://example.com?test=2&foo=baz&name=boaty&name=mcboatface')
         assert_response(resp, 'test')
-        resp = requests.get('http://example.com?foo=baz&test=2&name=mcboatface&name=boaty')
+        resp = requests.get(
+            'http://example.com?foo=baz&test=2&name=mcboatface&name=boaty')
         assert_response(resp, 'test')
 
     run()

--- a/test_responses.py
+++ b/test_responses.py
@@ -75,6 +75,23 @@ def test_match_querystring():
     assert_reset()
 
 
+def test_match_querystring_with_params():
+    @responses.activate
+    def run():
+        url = 'http://example.com'
+        query_params = {"test": 2, "foo": "baz", "name": ["boaty", "mcboatface"]}
+        responses.add(
+            responses.GET, url,
+            match_querystring=True, query_params=query_params, body=b'test')
+        resp = requests.get('http://example.com?test=2&foo=baz&name=boaty&name=mcboatface')
+        assert_response(resp, 'test')
+        resp = requests.get('http://example.com?foo=baz&test=2&name=mcboatface&name=boaty')
+        assert_response(resp, 'test')
+
+    run()
+    assert_reset()
+
+
 def test_match_querystring_error():
     @responses.activate
     def run():

--- a/test_responses.py
+++ b/test_responses.py
@@ -79,10 +79,12 @@ def test_match_querystring_with_params():
     @responses.activate
     def run():
         url = 'http://example.com'
-        query_params = {"test": 2, "foo": "baz", "name": ["boaty", "mcboatface"]}
+        query_params = {"test": 2, "foo": "baz",
+            "name": ["boaty", "mcboatface"]}
         responses.add(
             responses.GET, url,
-            match_querystring=True, query_params=query_params, body=b'test')
+            match_querystring=True, query_params=query_params,
+            body=b'test')
         resp = requests.get('http://example.com?test=2&foo=baz&name=boaty&name=mcboatface')
         assert_response(resp, 'test')
         resp = requests.get('http://example.com?foo=baz&test=2&name=mcboatface&name=boaty')


### PR DESCRIPTION
I wanted to add a mechanism to have the query string built in responses instead of doing so by hand.  I stole some structure from the requests library and tossed in a test and a snippet in the readme.
