### PR TITLE
Make the URL parameter to add() and add_callback() interpreted similarly (fixes #32)

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -159,7 +159,7 @@ class RequestsMock(object):
     def add_callback(self, method, url, callback, match_querystring=False,
                      content_type='text/plain'):
         # ensure the url has a default path set if the url is a string
-        # url = _ensure_url_default_path(url, match_querystring)
+        url = _ensure_url_default_path(url, match_querystring)
 
         self._urls.append({
             'url': url,


### PR DESCRIPTION
Uncommenting out the line appears to fully fix the open issue:

https://github.com/getsentry/responses/issues/32

The current code (with comment-out) makes `add()` and `add_callback()` change behavior with regard to input `url` parameter, which does not make sense.
