### PR TITLE
Add headers matching support

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -130,7 +130,7 @@ class RequestsMock(object):
 
     def add(self, method, url, body='', match_querystring=False,
             status=200, adding_headers=None, stream=False,
-            content_type='text/plain', json=None):
+            content_type='text/plain', json=None, headers=None):
 
         # if we were passed a `json` argument,
         # override the body and content_type
@@ -149,6 +149,7 @@ class RequestsMock(object):
             'url': url,
             'method': method,
             'body': body,
+            'headers': headers,
             'content_type': content_type,
             'match_querystring': match_querystring,
             'status': status,
@@ -187,6 +188,11 @@ class RequestsMock(object):
 
     def _find_match(self, request):
         for match in self._urls:
+            headers = match.get('headers')
+            if headers is not None and any(request.headers.get(h) != v
+                                           for h, v in headers.items()):
+                continue
+
             if request.method != match['method']:
                 continue
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -59,6 +59,31 @@ def test_connection_error():
     assert_reset()
 
 
+def test_match_headers_negative():
+    @responses.activate
+    def run():
+        url = 'http://example.com'
+        headers = {'Test header': 'Value'}
+        responses.add(responses.GET, url, headers=headers)
+        with pytest.raises(ConnectionError):
+            requests.get('http://example.com')
+
+    run()
+    assert_reset()
+
+
+def test_match_headers_positive():
+    @responses.activate
+    def run():
+        url = 'http://example.com'
+        headers = {'Test header': 'Value'}
+        responses.add(responses.GET, url, headers=headers)
+        requests.get('http://example.com', headers=headers)
+
+    run()
+    assert_reset()
+
+
 def test_match_querystring():
     @responses.activate
     def run():


### PR DESCRIPTION
Sometimes remote server response depends on headers were sent to, so we need to have some opportunity to mock different responses basing on request headers.

Example:
```
import requests

SOME_URL = 'http://example.com/some/url'
response1 = requests.get(SOME_URL, headers={'Content-Type': 'application/json'}
response2 = requests.get(SOME_URL, headers={'Content-Type': 'application/xml'}
```
 
and in tests we need to have:
```
 responses.add(responses.GET, SOME_URL, headers={'Content-Type': 'application/json'}, body=some_json_body)
 responses.add(responses.GET, SOME_URL, headers={'Content-Type': 'application/xml'}, body=some_xml_body)
```

@dcramer will be happy to get feedback from you.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/responses/114)

<!-- Reviewable:end -->
