### PR TITLE
Provide support for timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 .coverage
 .DS_Store
 .idea
+.eggs
 *.db
 *.egg-info
-*.pyc
+*.py[cod]
 /htmlcov
 /dist
 /build

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ lint:
 	@echo "Linting Python files"
 	PYFLAKES_NODOCTEST=1 flake8 .
 	@echo ""
+
+run-tests:
+	py.test -sv .

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,46 @@ Responses as a context manager
         resp.status_code == 404
 
 
+Timeout for request and response
+--------------------------------
+
+Sometimes it is useful to have an actual delay imitating network latency, so
+you can add ``timeout`` keyword argument to return a response with delay.
+
+.. code-block::python
+
+    import responses
+    import requests
+
+
+    def test_api_with_delay():
+        with responses.RequestsMock() as rsps:
+            rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
+                     body='{}', status=200,
+                     content_type='application/json', timeout=2)
+            # blocking call that will return after 2 seconds
+            resp = requests.get('http://twitter.com/api/1/foobar')
+
+You can hit a connection timeout exception if ``timeout`` argument is present
+for request.
+
+.. code-block::python
+
+    import responses
+    import requests
+
+
+    def test_connection_timeout():
+        with responses.RequestsMock() as rsps:
+            rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
+                     body='{}', status=200,
+                     content_type='application/json', timeout=2)
+            try:
+                resp = requests.get('http://twitter.com/api/1/foobar',
+                                    timeout=1)
+            except requests.exceptions.ConnectTimeout as e:
+                print('Connection timed out')
+
 Assertions on declared responses
 --------------------------------
 
@@ -166,3 +206,4 @@ the ``assert_all_requests_are_fired`` value:
             rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
                      body='{}', status=200,
                      content_type='application/json')
+

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Timeout for request and response
 Sometimes it is useful to have an actual delay imitating network latency, so
 you can add ``timeout`` keyword argument to return a response with delay.
 
-.. code-block::python
+.. code-block:: python
 
     import responses
     import requests
@@ -171,7 +171,7 @@ you can add ``timeout`` keyword argument to return a response with delay.
 You can hit a connection timeout exception if ``timeout`` argument is present
 for request.
 
-.. code-block::python
+.. code-block:: python
 
     import responses
     import requests

--- a/responses.py
+++ b/responses.py
@@ -12,8 +12,13 @@ from collections import namedtuple, Sequence, Sized
 from functools import update_wrapper
 from cookies import Cookies
 from requests.utils import cookiejar_from_dict
-from requests.exceptions import ConnectionError, ConnectTimeout
+from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
+
+try:
+    from requests.exceptions import ConnectTimeout
+except ImportError:
+    from requests.exceptions import Timeout as ConnectTimeout
 
 try:
     from requests.packages.urllib3.response import HTTPResponse

--- a/responses.py
+++ b/responses.py
@@ -2,6 +2,7 @@ from __future__ import (
     absolute_import, print_function, division, unicode_literals
 )
 
+import time
 import inspect
 import json as json_module
 import re
@@ -11,7 +12,7 @@ from collections import namedtuple, Sequence, Sized
 from functools import update_wrapper
 from cookies import Cookies
 from requests.utils import cookiejar_from_dict
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, ConnectTimeout
 from requests.sessions import REDIRECT_STATI
 
 try:
@@ -130,7 +131,7 @@ class RequestsMock(object):
 
     def add(self, method, url, body='', match_querystring=False,
             status=200, adding_headers=None, stream=False,
-            content_type='text/plain', json=None):
+            content_type='text/plain', json=None, timeout=None):
 
         # if we were passed a `json` argument,
         # override the body and content_type
@@ -154,10 +155,11 @@ class RequestsMock(object):
             'status': status,
             'adding_headers': adding_headers,
             'stream': stream,
+            'timeout': timeout,
         })
 
     def add_callback(self, method, url, callback, match_querystring=False,
-                     content_type='text/plain'):
+                     content_type='text/plain', timeout=None):
         # ensure the url has a default path set if the url is a string
         # url = _ensure_url_default_path(url, match_querystring)
 
@@ -167,6 +169,7 @@ class RequestsMock(object):
             'callback': callback,
             'content_type': content_type,
             'match_querystring': match_querystring,
+            'timeout': timeout,
         })
 
     @property
@@ -281,6 +284,15 @@ class RequestsMock(object):
             pass
 
         self._calls.add(request, response)
+
+        request_timeout = kwargs.get('timeout')
+        response_timeout = match.get('timeout')
+        if request_timeout is not None and response_timeout is not None:
+            if request_timeout < response_timeout:
+                raise ConnectTimeout()
+
+        if response_timeout:
+            time.sleep(response_timeout)
 
         return response
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -9,7 +9,12 @@ import responses
 import pytest
 
 from inspect import getargspec
-from requests.exceptions import ConnectionError, HTTPError, ConnectTimeout
+from requests.exceptions import ConnectionError, HTTPError
+
+try:
+    from requests.exceptions import ConnectTimeout
+except ImportError:
+    from requests.exceptions import Timeout as ConnectTimeout
 
 
 def assert_reset():

--- a/test_responses.py
+++ b/test_responses.py
@@ -3,7 +3,6 @@ from __future__ import (
 )
 
 import re
-import time
 import requests
 import responses
 import pytest
@@ -463,14 +462,14 @@ def test_response_timeout():
     @responses.activate
     def run():
         responses.add(responses.GET, url, body=body, timeout=timeout)
-        begin = time.time()
         resp = requests.get(url)
-        end = time.time()
-        assert end - begin >= timeout  # some additional delay may took place
         assert resp.text == 'test'
         assert resp.status_code == status
 
-    run()
+    with mock.patch('responses.time.sleep') as sleep_mock:
+        run()
+        sleep_mock.assert_called_once_with(timeout)
+
     assert_reset()
 
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -12,6 +12,11 @@ from inspect import getargspec
 from requests.exceptions import ConnectionError, HTTPError
 
 try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+try:
     from requests.exceptions import ConnectTimeout
 except ImportError:
     from requests.exceptions import Timeout as ConnectTimeout
@@ -477,13 +482,13 @@ def test_request_timeout():
     @responses.activate
     def run():
         responses.add(responses.GET, url, timeout=timeout)
-        begin = time.time()
         resp = requests.get(url, timeout=timeout)
-        end = time.time()
-        assert end - begin >= timeout
         assert resp.status_code == status
 
-    run()
+    with mock.patch('responses.time.sleep') as sleep_mock:
+        run()
+        sleep_mock.assert_called_once_with(timeout)
+
     assert_reset()
 
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -440,7 +440,7 @@ def test_request_timeout_expired():
     def run():
         responses.add(responses.GET, url, timeout=response_timeout)
         with pytest.raises(ConnectTimeout):
-            resp = requests.get(url, timeout=request_timeout)
+            requests.get(url, timeout=request_timeout)
 
     run()
     assert_reset()


### PR DESCRIPTION
It's useful to have an ability of specifying the delay when making a request. It helps in integration tests and allows imitating network latency.
Also `timeout` for request itself allow to test for `ConnectionTimeout` errors that is another one case to check in unittests.
## Changes
- Add makefile target for only launching py.test in verbose mode
- Update `.gitignore` file
- Add `timeout` keyword for `add` and `add_callback` methods

⌛ timeout ⏳ 
