### PR TITLE
document how to double raw response

### DIFF
--- a/test_responses.py
+++ b/test_responses.py
@@ -390,3 +390,14 @@ def test_allow_redirects_samehost():
 
     run()
     assert_reset()
+
+def test_use_stream_twice_to_double_raw_io():
+    @responses.activate
+    def run():
+        url = 'http://example.com'
+        responses.add(responses.GET, url, body=b'42', stream=True)
+        resp = requests.get(url, stream=True)
+        assert resp.raw.read() == b'42'
+
+    run()
+    assert_reset()

--- a/test_responses.py
+++ b/test_responses.py
@@ -391,6 +391,7 @@ def test_allow_redirects_samehost():
     run()
     assert_reset()
 
+
 def test_use_stream_twice_to_double_raw_io():
     @responses.activate
     def run():


### PR DESCRIPTION
so that `git grep` matches `raw` ( as on http://docs.python-requests.org/en/master/user/quickstart/#raw-response-content ) with test evidence

> `raw` is a _rare_ usage though, YMMV

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/responses/116)

<!-- Reviewable:end -->
