### PR TITLE
Added support for removing URLs from responses

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -156,6 +156,15 @@ class RequestsMock(object):
             'stream': stream,
         })
 
+    def remove(self, method, url, all_instances=True):
+        for mocked_url in self._urls:
+            if mocked_url['method'] == method and mocked_url['url'] == url:
+                self._urls.remove(mocked_url)
+                # responses allows for multiple registrations of the same
+                # URL/method pair so we must not break here
+        # Should we raise or return anything to let it know if we succeed
+        # (or failed) in removing the mock?
+
     def add_callback(self, method, url, callback, match_querystring=False,
                      content_type='text/plain'):
         # ensure the url has a default path set if the url is a string

--- a/test_responses.py
+++ b/test_responses.py
@@ -390,3 +390,36 @@ def test_allow_redirects_samehost():
 
     run()
     assert_reset()
+
+
+def test_allow_remove_mocked_url():
+    @responses.activate
+    def run():
+        url = 'http://example.com/'
+        # Adds a new response for POST
+        responses.add(
+            responses.POST,
+            url,
+            json={'foo': 'bar'},
+            status=201
+        )
+        # A new response for the same URL but for GET
+        responses.add(
+            responses.GET,
+            url,
+            json={'foo': 'baz'},
+            status=200
+        )
+        # Removes the URL for POST (because I might want to replace its
+        # response for something else
+        responses.remove(responses.POST, url)
+        # It should be possible to make a GET request
+        resp = requests.get(url)
+        assert resp.json()['foo'] == 'baz'
+
+        # But a POST request should not be possible
+        with pytest.raises(ConnectionError):
+            resp = requests.post(url)
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Hi Guys, I want to suggest the addition of a `remove` method to allow removing URL/method pairs from being mocked.

It happens quite often for me that I need to change a response for the same URL more than once during tests (because the same URL might return different kind of content depending on the input data).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/responses/117)
<!-- Reviewable:end -->
