### PR TITLE
Add section to README about using multiple responses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,3 +165,25 @@ can be disabled by passing the ``assert_all_requests_are_fired`` value:
             rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
                      body='{}', status=200,
                      content_type='application/json')
+
+Multiple Responses
+------------------
+You can also use ``assert_all_requests_are_fired`` to add multiple responses for the same url:
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+
+    def test_my_api():
+        with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+            rsps.add(responses.GET, 'http://twitter.com/api/1/foobar', status=500)
+            rsps.add(responses.GET, 'http://twitter.com/api/1/foobar',
+                     body='{}', status=200,
+                     content_type='application/json')
+
+            resp = requests.get('http://twitter.com/api/1/foobar')
+            assert resp.status_code == 500
+            resp = requests.get('http://twitter.com/api/1/foobar')
+            assert resp.status_code == 200


### PR DESCRIPTION
Describe how to use a secret feature in the responses library that I often (and otheres) find use for.

I created this since there doesnt seem to be any intention of merging #101 in, so it would be good to document how this is done without explicit support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/responses/123)
<!-- Reviewable:end -->
