### PR TITLE
Adjust example for requests>2.10 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Request callback
     def test_calc_api():
 
         def request_callback(request):
-            payload = json.loads(request.body)
+            payload = json.loads(request.body.decode('utf-8'))
             resp_body = {'value': sum(payload['numbers'])}
             headers = {'request-id': '728d329e-0e86-11e4-a748-0c84dc037c13'}
             return (200, headers, json.dumps(resp_body))


### PR DESCRIPTION
Test code of mine that executes `payload = json.loads(request.body)` in a responses callback, which was working with requests 2.10, has started failing after the release of requests 2.11.1 In requests 2.10 it seems that the `body` of a prepared request given to a responses callback could be a `str` but in 2.11.1 it is `bytes`. I've confirmed that `body.decode('utf-8')` is compatible with both requests 2.10.0 and 2.11.1.
