### PR TITLE
Skip `make lint` for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ install:
   - "pip install ${REQUESTS}"
   - make develop
 script:
-  - make lint
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then make lint; fi
   - py.test . --cov responses --cov-report term-missing


### PR DESCRIPTION
This PR skips linting for Python 2.6, which isn't supported by flake8 anymore.