### PR TITLE
Reraising exceptions when exiting context manager

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -177,9 +177,11 @@ class RequestsMock(object):
         self.start()
         return self
 
-    def __exit__(self, *args):
-        self.stop()
+    def __exit__(self, type, value, traceback):
+        success = type is None
+        self.stop(allow_assert=success)
         self.reset()
+        return success
 
     def activate(self, func):
         evaldict = {'responses': self, 'func': func}
@@ -296,9 +298,9 @@ class RequestsMock(object):
                                    unbound_on_send)
         self._patcher.start()
 
-    def stop(self):
+    def stop(self, allow_assert=True):
         self._patcher.stop()
-        if self.assert_all_requests_are_fired and self._urls:
+        if allow_assert and self.assert_all_requests_are_fired and self._urls:
             raise AssertionError(
                 'Not all requests have been executed {0!r}'.format(
                     [(url['method'], url['url']) for url in self._urls]))

--- a/test_responses.py
+++ b/test_responses.py
@@ -342,6 +342,13 @@ def test_assert_all_requests_are_fired():
         with pytest.raises(AssertionError):
             with responses.RequestsMock() as m:
                 m.add(responses.GET, 'http://example.com', body=b'test')
+
+        # check that assert_all_requests_are_fired doesn't swallow exceptions
+        with pytest.raises(ValueError):
+            with responses.RequestsMock() as m:
+                m.add(responses.GET, 'http://example.com', body=b'test')
+                raise ValueError()
+
     run()
     assert_reset()
 


### PR DESCRIPTION
Currently when using responses as a context manager with `assert_all_requests_are_fired`, any exception raised inside the `with` block will be swallowed if not all requests have been fired. This can obscure issues in the code unrelated to its requests behavior.

This pull request bypasses responses' assertion that all requests were fired when exiting the context manager due to a raised exception.