### PR TITLE
Added reason to mocked HTTPResponse

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -263,6 +263,7 @@ class RequestsMock(object):
 
         response = HTTPResponse(
             status=status,
+            reason=six.moves.http_client.responses[status],
             body=body,
             headers=headers,
             preload_content=False,

--- a/test_responses.py
+++ b/test_responses.py
@@ -18,6 +18,7 @@ def assert_reset():
 
 def assert_response(resp, body=None, content_type='text/plain'):
     assert resp.status_code == 200
+    assert resp.reason == 'OK'
     assert resp.headers['Content-Type'] == content_type
     assert resp.text == body
 
@@ -190,6 +191,7 @@ def test_throw_connection_error_explicit():
 def test_callback():
     body = b'test callback'
     status = 400
+    reason = 'Bad Request'
     headers = {'foo': 'bar'}
     url = 'http://example.com/'
 
@@ -202,6 +204,7 @@ def test_callback():
         resp = requests.get(url)
         assert resp.text == "test callback"
         assert resp.status_code == status
+        assert resp.reason == reason
         assert 'foo' in resp.headers
         assert resp.headers['foo'] == 'bar'
 


### PR DESCRIPTION
See #130 

> The field reason is missing from the mocked request. It is usually set to HTTP status code's readable name (eg. "OK" "Not Found")
> 
> This make some libraries, like requests_toolbelt dumping unhappy.