### PR TITLE
allow to return a response with no content-type header

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -244,9 +244,9 @@ class RequestsMock(object):
             self._calls.add(request, match['body'])
             raise match['body']
 
-        headers = {
-            'Content-Type': match['content_type'],
-        }
+        headers = {}
+        if match['content_type'] is not None:
+            headers['Content-Type'] = match['content_type']
 
         if 'callback' in match:  # use callback
             status, r_headers, body = match['callback'](request)


### PR DESCRIPTION
Recently I had to write some tests against an API endpoint which does not return a Content-Type header in the response.  This is bad practice on the part of the API in question of course, but currently it is impossible to simulate this with `responses`. 