### PR TITLE
Don't remove urls when assert_all_requests_are_fired=True

### DIFF
--- a/test_responses.py
+++ b/test_responses.py
@@ -393,6 +393,13 @@ def test_assert_all_requests_are_fired():
                 m.add(responses.GET, 'http://example.com', body=b'test')
                 raise ValueError()
 
+        # check that assert_all_requests_are_fired=True doesn't remove urls
+        with responses.RequestsMock(assert_all_requests_are_fired=True) as m:
+            m.add(responses.GET, 'http://example.com', body=b'test')
+            assert len(m._urls) == 1
+            requests.get('http://example.com')
+            assert len(m._urls) == 1
+
     run()
     assert_reset()
 


### PR DESCRIPTION
The only change in behaviour when setting `assert_all_requests_are_fired=True` should be the expected assertion. 

Prior to this PR, the url would be removed, thus a subsequent call to the same url hit the next match, or make a _real_ request if there was no match.

This is a breaking change as some users could be relying on the old behaviour. 