### PR TITLE
adding response_callbacks to improve compatibility

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 - Allow empty list/dict as json object (GH-100)
+- Added `response_callback`
 
 0.5.1
 -----

--- a/README.rst
+++ b/README.rst
@@ -188,3 +188,31 @@ You can also use ``assert_all_requests_are_fired`` to add multiple responses for
             assert resp.status_code == 500
             resp = requests.get('http://twitter.com/api/1/foobar')
             assert resp.status_code == 200
+
+Using a callback to modify the response
+---------------------------------------
+
+If you use customized processing in `requests` via subclassing/mixins, or if you
+have library tools that interact with `requests` at a low level, you may need
+to add extended processing to the mocked Response object to fully simlulate the
+environment for your tests.  A `response_callback` can be used, which will be
+wrapped by the library before being returned to the caller.  The callback
+accepts a `response` as it's single argument, and is expected to return a 
+single `response` object.
+
+
+.. code-block:: python
+
+    import responses
+    import requests
+
+	def response_callback(resp):
+		resp.callback_processed = True
+		return resp
+
+	with responses.RequestsMock(response_callback=response_callback) as m:
+		m.add(responses.GET, 'http://example.com', body=b'test')
+		resp = requests.get('http://example.com')
+		assert resp.text == "test"
+		assert hasattr(resp, 'callback_processed')
+		assert resp.callback_processed is True

--- a/test_responses.py
+++ b/test_responses.py
@@ -373,6 +373,22 @@ def test_response_cookies():
     assert_reset()
 
 
+def test_response_callback():
+    """adds a callback to decorate the response, then checks it"""
+    def run():
+        def response_callback(resp):
+            resp._is_mocked = True
+            return resp
+        with responses.RequestsMock(response_callback=response_callback) as m:
+            m.add(responses.GET, 'http://example.com', body=b'test')
+            resp = requests.get('http://example.com')
+            assert resp.text == "test"
+            assert hasattr(resp, '_is_mocked')
+            assert resp._is_mocked is True
+    run()
+    assert_reset()
+
+
 def test_assert_all_requests_are_fired():
     def run():
         with pytest.raises(AssertionError) as excinfo:


### PR DESCRIPTION
First off- this package is AMAZING. Thank you! You have greatly simplified my testing work, and have helped me move a large project so much closer to offline testing for everything. 

Unfortunately, the existing `responses` can't cover all our code and test cases easily. I needed the ability to either further-process or identify mocked responses and handle them slightly differently in a few situations. 

This PR is what I'm using locally and would like to offer upstream.  It simply adds a `response_callback` option, which can be used to perform additional processing on a response after generation.

A simple example is adding an attribute to note the response has been mocked.

An extended use-case: A package that I've open-sourced uses `requests` to fetch data, and uses a hook via mixins to inspect the socket and cache the upstream IP info onto the response object at a specific time. [This information is only available during a short window, and `urllib3` does not yet cache it.]  In most scenarios, not having this upstream IP info should raise a critical exception -- so the existing version of this library can not be used for testing my package, or certain software that uses it.

With this proposed `response_callback` feature, I can inject a fake peername into the processed response where it would have been cached if real.  This allows me to mock the real environment and run tests without adjusting the software.  For example, this solves my current problems:

    def response_callback(resp):
        resp._mp_peername = ('127.0.0.1', 80)
        return resp

    with responses.RequestsMock(assert_all_requests_are_fired=True, response_callback=response_callback) as rsps:
        ...
