### PR TITLE
fix: allow returning arbitrary status codes

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -232,7 +232,7 @@ class Response(BaseResponse):
 
         return HTTPResponse(
             status=status,
-            reason=six.moves.http_client.responses[status],
+            reason=six.moves.http_client.responses.get(status),
             body=body,
             headers=headers,
             preload_content=False, )
@@ -264,7 +264,7 @@ class CallbackResponse(BaseResponse):
 
         return HTTPResponse(
             status=status,
-            reason=six.moves.http_client.responses[status],
+            reason=six.moves.http_client.responses.get(status),
             body=body,
             headers=headers,
             preload_content=False, )

--- a/test_responses.py
+++ b/test_responses.py
@@ -211,6 +211,19 @@ def test_no_content_type():
     assert_reset()
 
 
+def test_arbitrary_status_code():
+    @responses.activate
+    def run():
+        url = 'http://example.com/'
+        responses.add(responses.GET, url, body='test', status=418)
+        resp = requests.get(url)
+        assert resp.status_code == 418
+        assert resp.reason is None
+
+    run()
+    assert_reset()
+
+
 def test_throw_connection_error_explicit():
     @responses.activate
     def run():


### PR DESCRIPTION
HTTPResponse.reason can be left blank. There is no reason to fail
for status codes like 418. It worked before 0.6.