### PR TITLE
Fix bug with reusing mocks out of order

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -386,13 +386,13 @@ class RequestsMock(object):
         return get_wrapped(func, _wrapper_template, evaldict)
 
     def _find_match(self, request):
-        for match in self._matches:
+        for i, match in enumerate(self._matches):
             if match.matches(request):
                 break
         else:
             return None
-        # shift matches
-        self._matches = self._matches[1:]
+        # move match to the end
+        self._matches = self._matches[0:i] + self._matches[i+1:]
         self._matches.append(match)
         return match
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -605,3 +605,18 @@ def test_multiple_responses():
 
     run()
     assert_reset()
+
+
+def test_multiple_responses_unordered():
+    @responses.activate
+    def run():
+        responses.add(responses.GET, 'http://example.com/foo', body='first')
+        responses.add(responses.GET, 'http://example.com/bar', body='second')
+
+        resp = requests.get('http://example.com/bar')
+        assert_response(resp, 'second')
+        resp = requests.get('http://example.com/foo')
+        assert_response(resp, 'first')
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Looks like responses 0.6.2 has a bug that shows up when you reuse mocks in a different order from how they are defined. Here's a test case to reproduce the bug, and a fix to make the test case pass.