### PR TITLE
Issue #170: Fix bug with handling multiple matches

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -386,13 +386,13 @@ class RequestsMock(object):
         return get_wrapped(func, _wrapper_template, evaldict)
 
     def _find_match(self, request):
-        for match in self._matches:
+        for i, match in enumerate(self._matches):
             if match.matches(request):
                 break
         else:
             return None
-        # shift matches
-        self._matches = self._matches[1:]
+        # move match to end
+        self._matches.pop(i)
         self._matches.append(match)
         return match
 

--- a/responses.py
+++ b/responses.py
@@ -386,15 +386,17 @@ class RequestsMock(object):
         return get_wrapped(func, _wrapper_template, evaldict)
 
     def _find_match(self, request):
+        found = None
+        found_match = None
         for i, match in enumerate(self._matches):
             if match.matches(request):
-                break
-        else:
-            return None
-        # move match to end
-        self._matches.pop(i)
-        self._matches.append(match)
-        return match
+                if found is None:
+                    found = i
+                    found_match = match
+                else:
+                    # Multiple matches found.  Remove & return the first match.
+                    return self._matches.pop(found)
+        return found_match
 
     def _on_request(self, adapter, request, **kwargs):
         match = self._find_match(request)

--- a/test_responses.py
+++ b/test_responses.py
@@ -606,6 +606,9 @@ def test_multiple_responses():
         assert_response(resp, 'test')
         resp = requests.get('http://example.com')
         assert_response(resp, 'rest')
+        # After all responses are used, last response should be repeated
+        resp = requests.get('http://example.com')
+        assert_response(resp, 'rest')
 
     run()
     assert_reset()


### PR DESCRIPTION
Fixes a bug (#170) where the list of matches is incorrectly updated after a match, leading to issues with multiple responses.

I'm not entirely sure why the list of matches is being rotated in the first place, so this may create some other unwanted side effect.