### PR TITLE
Adds unicode handling to _url_matches,  fixes issue #175

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -53,19 +53,22 @@ logger = logging.getLogger('responses')
 def _is_string(s):
     return isinstance(s, six.string_types)
 
+
 def _has_unicode(s):
     return any(ord(char) > 128 for char in s)
+
 
 def _clean_unicode(url):
     if isinstance(url.encode('utf8'), six.string_types):
         url = url.encode('utf8')
     chars = list(url)
-    for i,x in enumerate(chars):
+    for i, x in enumerate(chars):
         if ord(x) > 128:
             chars[i] = quote(x)
 
     return ''.join(chars)
-    
+
+
 def _is_redirect(response):
     try:
         # 2.0.0 <= requests <= 2.2
@@ -175,13 +178,13 @@ class BaseResponse(object):
     def _url_matches_strict(self, url, other):
         url_parsed = urlparse(url)
         other_parsed = urlparse(other)
-        
+
         if url_parsed[:3] != other_parsed[:3]:
             return False
 
         url_qsl = sorted(parse_qsl(url_parsed.query))
         other_qsl = sorted(parse_qsl(other_parsed.query))
-        
+
         if len(url_qsl) != len(other_qsl):
             return False
 
@@ -197,7 +200,7 @@ class BaseResponse(object):
             if _has_unicode(url):
                 url = _clean_unicode(url)
                 if not isinstance(other, six.text_type):
-                    other = unicode(other, 'ascii')
+                    other = other.encode('ascii').decode('utf8')
             if match_querystring:
                 return self._url_matches_strict(url, other)
             else:

--- a/test_responses.py
+++ b/test_responses.py
@@ -648,12 +648,27 @@ def test_allow_redirects_samehost():
     assert_reset()
 
 
-def test_handles_chinese_url():
+def test_handles_unicode_querystring():
     url = u'http://example.com/test?type=2&ie=utf8&query=汉字'
 
     @responses.activate
     def run():
         responses.add(responses.GET, url, body='test', match_querystring=True)
+
+        resp = requests.get(url)
+
+        assert_response(resp, 'test')
+
+    run()
+    assert_reset()
+
+
+def test_handles_unicode_url():
+    url = u'https://hi.wikipedia.org/wiki/दिलवाले_दुल्हनिया_ले_जाएंगे'
+
+    @responses.activate
+    def run():
+        responses.add(responses.GET, url, body='test')
 
         resp = requests.get(url)
 


### PR DESCRIPTION
Fixes #175 by doing some validation during `_url_matches`

At first it was during BaseRequest init, but that broke some things, so I changed it. Now the tests pass and I added another one to validate URLs with unicode in the path, not just the query string.

Note that a test like this

```python
import requests
import responses

@responses.activate
def test_simple():
     responses.add(responses.GET, 'https://hi.wikipedia.org/wiki/दिलवाले_दुल्हनिया_ले_जाएंगे',
                   status=200)

     resp = requests.get('https://hi.wikipedia.org/wiki/दिलवाले_दुल्हनिया_ले_जाएंगे')

     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'https://hi.wikipedia.org/wiki/दिलवाले_दुल्हनिया_ले_जाएंगे'
     assert responses.calls[0].response.status_code == 200

test_simple()
```
will fail the second-to-last assertion. But it seems reasonable, since the same thing will happen with this test:

```python
import requests
import responses

@responses.activate
def test_simple():
     responses.add(responses.GET, 'https:/duckduckgo.com/html?s=as as',
                   status=200)

     resp = requests.get('https:/duckduckgo.com/html?s=as as')

     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'https:/duckduckgo.com/html?s=as as'
     assert responses.calls[0].response.status_code == 200

test_simple()
```
as the space in the url (`s=as as`) is url-encoded to `%20` when the request is made, just as the unicode characters are url-encoded.