### PR TITLE
Add support for unicode in domain names and tlds

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -11,7 +11,6 @@ import six
 from collections import namedtuple, Sequence, Sized
 from functools import update_wrapper
 from cookies import Cookies
-from publicsuffixlist import PublicSuffixList
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
@@ -49,9 +48,6 @@ def wrapper%(signature)s:
 """
 
 logger = logging.getLogger('responses')
-
-psl = PublicSuffixList()
-
 
 def _is_string(s):
     return isinstance(s, six.string_types)
@@ -217,8 +213,6 @@ class BaseResponse(object):
                 url = _clean_unicode(url)
                 if not isinstance(other, six.text_type):
                     other = other.encode('ascii').decode('utf8')
-                print(url)
-                print(other)
             if match_querystring:
                 return self._url_matches_strict(url, other)
             else:

--- a/responses.py
+++ b/responses.py
@@ -49,6 +49,7 @@ def wrapper%(signature)s:
 
 logger = logging.getLogger('responses')
 
+
 def _is_string(s):
     return isinstance(s, six.string_types)
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     'requests>=2.0',
     'cookies',
     'six',
+    'publicsuffixlist'
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ if 'test' in sys.argv:
 install_requires = [
     'requests>=2.0',
     'cookies',
-    'six',
-    'publicsuffixlist'
+    'six'
 ]
 
 tests_require = [

--- a/test_responses.py
+++ b/test_responses.py
@@ -664,7 +664,7 @@ def test_handles_unicode_querystring():
 
 
 def test_handles_unicode_url():
-    url = u'https://hi.wikipedia.org/wiki/दिलवाले_दुल्हनिया_ले_जाएंगे'
+    url = u'http://www.संजाल.भारत/hi/वेबसाइट-डिजाइन'
 
     @responses.activate
     def run():


### PR DESCRIPTION
Earlier versions would have URLs like http://www.संजाल.भारत/hi/वेबसाइट-डिजाइन result in a connection error. This PR fixes that by encoding unicode in domain names and TLDs correctly when matching URLs.