### PR TITLE
Add max_retries option to RequestsMock

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -560,6 +560,7 @@ class RequestsMock(object):
             import mock
 
         def unbound_on_send(adapter, request, *a, **kwargs):
+            retries = adapter.max_retries if isinstance(adapter.max_retries, int) else adapter.max_retries.total
             return self._on_request(adapter, request, adapter.max_retries.total, *a, **kwargs)
 
         self._patcher = mock.patch('requests.adapters.HTTPAdapter.send',

--- a/responses.py
+++ b/responses.py
@@ -341,14 +341,12 @@ class RequestsMock(object):
     def __init__(self,
                  assert_all_requests_are_fired=True,
                  response_callback=None,
-                 passthru_prefixes=(),
-                 max_retries=0):
+                 passthru_prefixes=()):
         self._calls = CallList()
         self.reset()
         self.assert_all_requests_are_fired = assert_all_requests_are_fired
         self.response_callback = response_callback
         self.passthru_prefixes = tuple(passthru_prefixes)
-        self.max_retries = max_retries
 
     def reset(self):
         self._matches = []
@@ -536,8 +534,7 @@ class RequestsMock(object):
             self._calls.add(request, response)
             response = resp_callback(response) if resp_callback else response
             if retries > 0:
-                retries -= 1
-                return self._on_request(adapter, request, retries, **kwargs)
+                return self._on_request(adapter, request, retries-1, **kwargs)
             else:
                 raise
 
@@ -563,7 +560,7 @@ class RequestsMock(object):
             import mock
 
         def unbound_on_send(adapter, request, *a, **kwargs):
-            return self._on_request(adapter, request, self.max_retries, *a, **kwargs)
+            return self._on_request(adapter, request, adapter.max_retries.total, *a, **kwargs)
 
         self._patcher = mock.patch('requests.adapters.HTTPAdapter.send',
                                    unbound_on_send)

--- a/responses.py
+++ b/responses.py
@@ -561,7 +561,7 @@ class RequestsMock(object):
 
         def unbound_on_send(adapter, request, *a, **kwargs):
             retries = adapter.max_retries if isinstance(adapter.max_retries, int) else adapter.max_retries.total
-            return self._on_request(adapter, request, adapter.max_retries.total, *a, **kwargs)
+            return self._on_request(adapter, request, retries, *a, **kwargs)
 
         self._patcher = mock.patch('requests.adapters.HTTPAdapter.send',
                                    unbound_on_send)

--- a/responses.py
+++ b/responses.py
@@ -560,7 +560,10 @@ class RequestsMock(object):
             import mock
 
         def unbound_on_send(adapter, request, *a, **kwargs):
-            retries = adapter.max_retries if isinstance(adapter.max_retries, int) else adapter.max_retries.total
+            if isinstance(adapter.max_retries, int):
+                retries = adapter.max_retries
+            else:
+                retries = adapter.max_retries.total
             return self._on_request(adapter, request, retries, *a, **kwargs)
 
         self._patcher = mock.patch('requests.adapters.HTTPAdapter.send',


### PR DESCRIPTION
Issue #135 shows a number of people who want to use `responses` to mock requests to a website and retries of that request to the same website.

Not sure why people want to do this, but if it's something desirable, this should allow for that. Usage would look like this (script will run without raising a `ConnectionError`.

```python
import responses
import requests

exception = ConnectionError('Bad connection')
url = 'https://www.example.com'
with responses.RequestsMock(assert_all_requests_are_fired=False, max_retries=3) as rsp:
   rsp.add(responses.POST, url, body=exception)
   rsp.add(responses.POST, url, body=exception)
   rsp.add(responses.POST, url, body=exception)
   rsp.add(responses.POST, url, body='{}')
   requests.post(url=url, json={})
```