### PR TITLE
Add stream attribute to BaseResponse

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -160,6 +160,7 @@ def _handle_body(body):
 class BaseResponse(object):
     content_type = None
     headers = None
+
     stream = False
 
     def __init__(self, method, url, match_querystring=False):

--- a/responses.py
+++ b/responses.py
@@ -160,6 +160,7 @@ def _handle_body(body):
 class BaseResponse(object):
     content_type = None
     headers = None
+    stream = False
 
     def __init__(self, method, url, match_querystring=False):
         self.method = method


### PR DESCRIPTION
According to RequestMock.add, one can use any `BaseResponse` subclass,
and `BaseResponse` only requires implementing `get_response`.

However when one tries to do so `_on_request` blows up as it *always* checks for `match.stream`, which `BaseResponse` doesn't implement, and thus it blows up until one sets that attribute.

Adding `stream = False` at the class level should fix it and not break anything.