### PR TITLE
Fix pass-thru requests losing additional settings

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -531,7 +531,7 @@ class RequestsMock(object):
                     'request.allowed-passthru', extra={
                         'url': request.url,
                     })
-                return _real_send(adapter, request)
+                return _real_send(adapter, request, **kwargs)
 
             error_msg = 'Connection refused: {0} {1}'.format(
                 request.method, request.url)


### PR DESCRIPTION
This one is pretty straightforward, some request-settings are not getting passed along for stuff like proxies and certificates.

In my particular use-case the fix is essential because a SOCKS proxy is the only way to access the external resource. (Without `socks5h://` I can't even resolve the internal hostname.)