### PR TITLE
Alow extra keyword arguments to be passed to the callback function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,27 @@ a tuple of (``status``, ``headers``, ``body``).
             '728d329e-0e86-11e4-a748-0c84dc037c13'
         )
 
+If you want to pass extra keyword arguments to the callback function, for example when reusing
+a callback function to give a slightly different result, you can use ``functools.partial``:
+
+.. code-block:: python
+
+    from functools import partial
+
+    ...
+
+        def request_callback(request, id=None):
+            payload = json.loads(request.body)
+            resp_body = {'value': sum(payload['numbers'])}
+            headers = {'request-id': id}
+            return (200, headers, json.dumps(resp_body))
+
+        responses.add_callback(
+            responses.POST, 'http://calc.com/sum',
+            callback=partial(request_callback, id='728d329e-0e86-11e4-a748-0c84dc037c13',
+            content_type='application/json',
+        )
+
 
 Responses as a context manager
 ------------------------------

--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ a callback function to give a slightly different result, you can use ``functools
 
         responses.add_callback(
             responses.POST, 'http://calc.com/sum',
-            callback=partial(request_callback, id='728d329e-0e86-11e4-a748-0c84dc037c13',
+            callback=partial(request_callback, id='728d329e-0e86-11e4-a748-0c84dc037c13'),
             content_type='application/json',
         )
 


### PR DESCRIPTION
Sometimes you need to register the same callback function multiple time, but with slightly different behavior (ex. a different username in the response). Being able to pass arguments to the callback function makes for less code duplication.