### PR TITLE
Install test extras in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,6 @@
 envlist = {py26,py27,py32,py33,py34,py35}
 
 [testenv]
-deps =
-    pytest
-    pytest-cov
-    pytest-flakes
+extras = tests
 commands =
-    py.test . --cov responses --cov-report term-missing --flakes
+    py.test . --cov responses --cov-report term-missing


### PR DESCRIPTION
Without this, running `tox` fails because none of the test dependencies are installed.