### PR TITLE
Change match_querystring default to consider URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,9 @@ url (``str`` or compiled regular expression)
     The full resource URL.
 
 match_querystring (``bool``)
-    Disabled by default. Include the query string when matching requests.
+    Include the query string when matching requests.
+    Enabled by default if the response URL contains a query string,
+    disabled if it doesn't or the URL is a regular expression.
 
 body (``str`` or ``BufferedReader``)
     The response body.

--- a/test_responses.py
+++ b/test_responses.py
@@ -302,6 +302,19 @@ def test_match_querystring_error_regex():
     assert_reset()
 
 
+def test_match_querystring_auto_activates():
+    @responses.activate
+    def run():
+        responses.add(responses.GET, "http://example.com?test=1", body=b"test")
+        resp = requests.get("http://example.com?test=1")
+        assert_response(resp, "test")
+        with pytest.raises(ConnectionError):
+            requests.get("http://example.com/?test=2")
+
+    run()
+    assert_reset()
+
+
 def test_accept_string_body():
     @responses.activate
     def run():


### PR DESCRIPTION
Previously, adding a response with a query string without also setting
match_querystring=True would provide confusing results, see #211.

This commit changes the argument's default value to consider the URL and
automatically enable match_querystring if a query string is detected in
the response.