### PR TITLE
Import collections ABCs from collections.abc if possible

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -7,13 +7,18 @@ import logging
 import re
 import six
 
-from collections import namedtuple, Sequence, Sized
+from collections import namedtuple
 from functools import update_wrapper
 from cookies import Cookies
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
 from requests.utils import cookiejar_from_dict
+
+try:
+    from collections.abc import Sequence, Sized
+except ImportError:
+    from collections import Sequence, Sized
 
 try:
     from requests.packages.urllib3.response import HTTPResponse


### PR DESCRIPTION
"`from collections import Sequence, Sized`" produces a `DeprecationWarning` under Python 3.7 with the message:

> Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

This patch eliminates this warning by importing from `collections.abc` instead, falling back to `collections` only if that fails (i.e., if running under Python < 3.3).
