### PR TITLE
use biscuits on Python 3, cookies on Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'

--- a/responses.py
+++ b/responses.py
@@ -107,12 +107,14 @@ def _is_redirect(response):
 
 
 def _cookies_from_headers(headers):
-    if sys.version_info[:2] < (3,4):
+    if sys.version_info[:2] < (3, 4):
         from cookies import Cookies
+
         resp_cookies = Cookies.from_request(headers["set-cookie"])
         cookies_dict = {v.name: v.value for _, v in resp_cookies.items()}
     else:
         import biscuits
+
         cookies_dict = biscuits.parse(headers["set-cookie"])
     return cookiejar_from_dict(cookies_dict)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ setup_requires = []
 if "test" in sys.argv:
     setup_requires.append("pytest")
 
-install_requires = ["requests>=2.0", "cookies;python_version<'3.4'", "biscuits;python_version>='3.4'", "six"]
+install_requires = [
+    "requests>=2.0",
+    "cookies;python_version<'3.4'",
+    "biscuits;python_version>='3.4'",
+    "six",
+]
 
 tests_require = [
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup_requires = []
 if "test" in sys.argv:
     setup_requires.append("pytest")
 
-install_requires = ["requests>=2.0", "cookies", "six"]
+install_requires = ["requests>=2.0", "cookies;python_version<'3.4'", "biscuits;python_version>='3.4'", "six"]
 
 tests_require = [
     "pytest",

--- a/test_responses.py
+++ b/test_responses.py
@@ -15,7 +15,8 @@ if six.PY2:
     from inspect import getargspec
 else:
     from inspect import getfullargspec as getargspec
-    
+
+
 def assert_reset():
     assert len(responses._default_mock._matches) == 0
     assert len(responses.calls) == 0

--- a/test_responses.py
+++ b/test_responses.py
@@ -3,15 +3,19 @@
 from __future__ import absolute_import, print_function, division, unicode_literals
 
 import re
-import requests
-import responses
+
 import pytest
-from responses import BaseResponse, Response
-
-from inspect import getargspec
+import requests
 from requests.exceptions import ConnectionError, HTTPError
+import responses
+from responses import BaseResponse, Response
+import six
 
-
+if six.PY2:
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec as getargspec
+    
 def assert_reset():
     assert len(responses._default_mock._matches) == 0
     assert len(responses.calls) == 0


### PR DESCRIPTION
This pull request addresses issue #186 by using the [biscuits](https://github.com/pyrates/biscuits) package instead of [cookies](https://gitlab.com/sashahart/cookies/) when on Python >= 3.4. Biscuits does not support Python < 3.4 so the original behavior is maintained there.
