### PR TITLE
Fix warnings from formatargspec

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -144,15 +144,15 @@ def get_wrapped(func, responses):
             signature = signature.replace(parameters=new_params)
 
         params_without_defaults = [
-            param.replace(default=inspect.Parameter.empty) for
-            param in signature.parameters.values()
+            param.replace(default=inspect.Parameter.empty)
+            for param in signature.parameters.values()
         ]
         signature = signature.replace(parameters=params_without_defaults)
         func_args = str(signature)
 
     evaldict = {"func": func, "responses": responses}
     six.exec_(
-        _wrapper_template % {'wrapper_args': wrapper_args, 'func_args': func_args},
+        _wrapper_template % {"wrapper_args": wrapper_args, "func_args": func_args},
         evaldict,
     )
     wrapper = evaldict["wrapper"]

--- a/test_responses.py
+++ b/test_responses.py
@@ -529,7 +529,9 @@ def test_activate_doesnt_change_signature_for_method():
 
         decorated_test_function = responses.activate(test_function)
 
-    assert getargspec(TestCase.test_function) == getargspec(TestCase.decorated_test_function)
+    assert getargspec(TestCase.test_function) == getargspec(
+        TestCase.decorated_test_function
+    )
     test_case = TestCase()
     assert test_case.decorated_test_function(1, 2) == test_case.test_function(1, 2)
     assert test_case.decorated_test_function(3) == test_case.test_function(3)

--- a/test_responses.py
+++ b/test_responses.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, print_function, division, unicode_literals
 
+import inspect
 import re
 
 import pytest
@@ -10,11 +11,6 @@ from requests.exceptions import ConnectionError, HTTPError
 import responses
 from responses import BaseResponse, Response
 import six
-
-if six.PY2:
-    from inspect import getargspec
-else:
-    from inspect import getfullargspec as getargspec
 
 
 def assert_reset():
@@ -517,7 +513,14 @@ def test_activate_doesnt_change_signature():
         return (a, b)
 
     decorated_test_function = responses.activate(test_function)
-    assert getargspec(test_function) == getargspec(decorated_test_function)
+    if hasattr(inspect, "signature"):
+        assert inspect.signature(test_function) == inspect.signature(
+            decorated_test_function
+        )
+    else:
+        assert inspect.getargspec(test_function) == inspect.getargspec(
+            decorated_test_function
+        )
     assert decorated_test_function(1, 2) == test_function(1, 2)
     assert decorated_test_function(3) == test_function(3)
 
@@ -529,9 +532,6 @@ def test_activate_doesnt_change_signature_for_method():
 
         decorated_test_function = responses.activate(test_function)
 
-    assert getargspec(TestCase.test_function) == getargspec(
-        TestCase.decorated_test_function
-    )
     test_case = TestCase()
     assert test_case.decorated_test_function(1, 2) == test_case.test_function(1, 2)
     assert test_case.decorated_test_function(3) == test_case.test_function(3)

--- a/test_responses.py
+++ b/test_responses.py
@@ -527,12 +527,12 @@ def test_activate_doesnt_change_signature_for_method():
         def test_function(self, a, b=None):
             return (self, a, b)
 
+        decorated_test_function = responses.activate(test_function)
+
+    assert getargspec(TestCase.test_function) == getargspec(TestCase.decorated_test_function)
     test_case = TestCase()
-    argspec = getargspec(test_case.test_function)
-    decorated_test_function = responses.activate(test_case.test_function)
-    assert argspec == getargspec(decorated_test_function)
-    assert decorated_test_function(1, 2) == test_case.test_function(1, 2)
-    assert decorated_test_function(3) == test_case.test_function(3)
+    assert test_case.decorated_test_function(1, 2) == test_case.test_function(1, 2)
+    assert test_case.decorated_test_function(3) == test_case.test_function(3)
 
 
 def test_response_cookies():

--- a/test_responses.py
+++ b/test_responses.py
@@ -10,7 +10,6 @@ import requests
 from requests.exceptions import ConnectionError, HTTPError
 import responses
 from responses import BaseResponse, Response
-import six
 
 
 def assert_reset():


### PR DESCRIPTION
Fixes #216. Use Python 3's `inspect.signature` to replace the argument specification in the wrapper function.