### PR TITLE
Don't use a dependency to parse cookies in py3

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -113,8 +113,9 @@ def _is_redirect(response):
 def _cookies_from_headers(headers):
     try:
         import http.cookies as cookies
+
         resp_cookie = cookies.SimpleCookie()
-        resp_cookie.load(headers['set-cookie'])
+        resp_cookie.load(headers["set-cookie"])
 
         cookies_dict = {name: v.value for name, v in resp_cookie.items()}
     except ImportError:

--- a/responses.py
+++ b/responses.py
@@ -6,7 +6,6 @@ import json as json_module
 import logging
 import re
 import six
-import sys
 
 from collections import namedtuple
 from functools import update_wrapper
@@ -112,15 +111,17 @@ def _is_redirect(response):
 
 
 def _cookies_from_headers(headers):
-    if sys.version_info[:2] < (3, 4):
+    try:
+        import http.cookies as cookies
+        resp_cookie = cookies.SimpleCookie()
+        resp_cookie.load(headers['set-cookie'])
+
+        cookies_dict = {name: v.value for name, v in resp_cookie.items()}
+    except ImportError:
         from cookies import Cookies
 
         resp_cookies = Cookies.from_request(headers["set-cookie"])
         cookies_dict = {v.name: v.value for _, v in resp_cookies.items()}
-    else:
-        import biscuits
-
-        cookies_dict = biscuits.parse(headers["set-cookie"])
     return cookiejar_from_dict(cookies_dict)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,7 @@ setup_requires = []
 if "test" in sys.argv:
     setup_requires.append("pytest")
 
-install_requires = [
-    "requests>=2.0",
-    "cookies;python_version<'3.4'",
-    "six",
-]
+install_requires = ["requests>=2.0", "cookies;python_version<'3.4'", "six"]
 
 tests_require = [
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ if "test" in sys.argv:
 install_requires = [
     "requests>=2.0",
     "cookies;python_version<'3.4'",
-    "biscuits;python_version>='3.4'",
     "six",
 ]
 


### PR DESCRIPTION
Instead of adding a dependency to parse cookies in python3 we can use stdlib features.