### PR TITLE
fix(py3) Fix syntax error when generating wrappers

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -149,7 +149,12 @@ def get_wrapped(func, responses):
                 inspect.Parameter("args", inspect.Parameter.VAR_POSITIONAL),
                 inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD),
             ]
-            signature = signature.replace(parameters=wrapper_params)
+        else:
+            wrapper_params = [
+                param.replace(annotation=inspect.Parameter.empty)
+                for param in signature.parameters.values()
+            ]
+        signature = signature.replace(parameters=wrapper_params)
 
         wrapper_args = str(signature)
         params_without_defaults = [

--- a/test_responses.py
+++ b/test_responses.py
@@ -560,7 +560,7 @@ def test_activate_doesnt_change_signature_with_return_type():
     # Add type annotations as they are syntax errors in py2.
     # Use a class to test for import errors in evaled code.
     test_function.__annotations__["return"] = Mock
-    test_function.__annotations__["a"] = str
+    test_function.__annotations__["a"] = Mock
 
     decorated_test_function = responses.activate(test_function)
     if hasattr(inspect, "signature"):


### PR DESCRIPTION
When generating wrappers for functions with parameter & return annotations we need to remove the annotation from the generated code snippet.

Fixes #230