### PR TITLE
Fix callback exception mocking.

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -6,6 +6,7 @@ import json as json_module
 import logging
 import re
 import six
+import warnings
 
 from collections import namedtuple
 from functools import update_wrapper
@@ -387,9 +388,19 @@ class CallbackResponse(BaseResponse):
 
         result = self.callback(request)
         if isinstance(result, Exception):
+            warnings.warn(
+                "Callbacks should always return a (status, headers, body) "
+                "tuple. To mock an exception, provide that exception as "
+                "the body in the tuple. Support for exception responses "
+                "from callbacks will be removed in version 1.0.0.",
+                DeprecationWarning,
+            )
             raise result
 
         status, r_headers, body = result
+        if isinstance(body, Exception):
+            raise body
+
         body = _handle_body(body)
         headers.update(r_headers)
 
@@ -647,3 +658,7 @@ __all__ = ["CallbackResponse", "Response", "RequestsMock"]
 for __attr in (a for a in dir(_default_mock) if not a.startswith("_")):
     __all__.append(__attr)
     globals()[__attr] = getattr(_default_mock, __attr)
+
+
+# Turn on our deprecation warnings for API users.
+warnings.filterwarnings(action="default", category=DeprecationWarning, module=__name__)

--- a/responses.py
+++ b/responses.py
@@ -6,7 +6,6 @@ import json as json_module
 import logging
 import re
 import six
-import warnings
 
 from collections import namedtuple
 from functools import update_wrapper
@@ -388,13 +387,6 @@ class CallbackResponse(BaseResponse):
 
         result = self.callback(request)
         if isinstance(result, Exception):
-            warnings.warn(
-                "Callbacks should always return a (status, headers, body) "
-                "tuple. To mock an exception, provide that exception as "
-                "the body in the tuple. Support for exception responses "
-                "from callbacks will be removed in version 1.0.0.",
-                DeprecationWarning,
-            )
             raise result
 
         status, r_headers, body = result
@@ -658,7 +650,3 @@ __all__ = ["CallbackResponse", "Response", "RequestsMock"]
 for __attr in (a for a in dir(_default_mock) if not a.startswith("_")):
     __all__.append(__attr)
     globals()[__attr] = getattr(_default_mock, __attr)
-
-
-# Turn on our deprecation warnings for API users.
-warnings.filterwarnings(action="default", category=DeprecationWarning, module=__name__)

--- a/test_responses.py
+++ b/test_responses.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 import inspect
 import re
 import six
-import warnings
 
 import pytest
 import requests
@@ -430,12 +429,8 @@ def test_callback_exception_result():
         responses.add_callback(responses.GET, url, request_callback)
 
         with pytest.raises(Exception) as e:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                requests.get(url)
+            requests.get(url)
 
-        assert len(w) == 1
-        assert issubclass(w[0].category, DeprecationWarning)
         assert e.value is result
 
     run()


### PR DESCRIPTION
It now works like regular response mocking where a body that
is an Exception subclass triggers that exception to be raised.
Support for the existing undocumented callback-only behavior
is retained but a deprecation warning issued. Tests are added
for both of these cases.

Fixes #234