### PR TITLE
removed extra comma in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ passed directly:
         responses.Response(
             method='GET',
             url='http://example.com',
-        ),
+        )
     )
 
 The following attributes can be passed to a Response mock:


### PR DESCRIPTION
@getsentry I've really been digging `responses`! I've found it easier to work with than `unittest.mock`. Thanks for providing it!

Please consider this small PR to remove a trailing comma I noticed while going through the README.