### PR TITLE
Added matches property to RequestMock. Updated documentation for modifying responses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,6 +360,35 @@ This will allow any requests matching that prefix, that is otherwise not registe
 as a mock response, to passthru using the standard behavior.
 
 
+Modifying registered responses
+------------------------------
+
+The ``replace`` function allows a previously registered ``response`` to be
+changed. The method signature is identical to ``add``. ``response``s are
+identified using ``method`` and ``url``. Only the first matched ``response`` is
+replaced.
+
+..  code-block:: python
+
+    import responses
+    import requests
+
+    @responses.activate
+    def test_replace():
+
+        responses.add(responses.GET, 'http://example.org', json={'data': 1})
+        responses.replace(responses.GET, 'http://example.org', json={'data': 2})
+
+        resp = requests.get('http://example.org')
+
+        assert resp.json() == {'data': 2}
+
+
+``remove`` takes a ``method`` and ``url`` argument and will remove *all*
+matched ``response``s from the registered list.
+
+Finally, ``clear`` will reset all registered ``response``s
+
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -360,8 +360,12 @@ This will allow any requests matching that prefix, that is otherwise not registe
 as a mock response, to passthru using the standard behavior.
 
 
-Modifying registered responses
+Viewing/Modifying registered responses
 ------------------------------
+
+Registered responses are available as a private attribute of the RequestMock
+instance. It is sometimes useful for debugging purposes to view the stack of
+registered responses which can be accessed via ``responses.mock._matches``.
 
 The ``replace`` function allows a previously registered ``response`` to be
 changed. The method signature is identical to ``add``. ``response``s are
@@ -388,6 +392,7 @@ replaced.
 matched ``response``s from the registered list.
 
 Finally, ``clear`` will reset all registered ``response``s
+
 
 
 Contributing

--- a/responses.py
+++ b/responses.py
@@ -553,6 +553,10 @@ class RequestsMock(object):
     def calls(self):
         return self._calls
 
+    @property
+    def matches(self):
+        return self._matches
+
     def __enter__(self):
         self.start()
         return self

--- a/responses.py
+++ b/responses.py
@@ -553,10 +553,6 @@ class RequestsMock(object):
     def calls(self):
         return self._calls
 
-    @property
-    def matches(self):
-        return self._matches
-
     def __enter__(self):
         self.start()
         return self


### PR DESCRIPTION
Referencing https://github.com/getsentry/responses/issues/252#event-2089058954 this PR adds a property that can be used to check the `_matches` property on the `RequestsMock`. Also updated the documentation to add some detail around replacing/removing registered responses