### PR TITLE
Clean up 'mock' requirement declaration in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,21 @@ A utility library for mocking out the `requests` Python library.
 """
 
 import sys
-import logging
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
-import pkg_resources
 
 setup_requires = []
 
 if "test" in sys.argv:
     setup_requires.append("pytest")
 
-install_requires = ["requests>=2.0", "cookies;python_version<'3.4'", "six"]
+install_requires = [
+    "cookies; python_version < '3.4'",
+    "mock; python_version < '3.3'",
+    "requests>=2.0",
+    "six",
+]
 
 tests_require = [
     "pytest",
@@ -31,24 +34,7 @@ tests_require = [
     "flake8",
 ]
 
-extras_require = {
-    ':python_version in "2.6, 2.7, 3.2"': ["mock"],
-    "tests": tests_require,
-}
-
-try:
-    if "bdist_wheel" not in sys.argv:
-        for key, value in extras_require.items():
-            if key.startswith(":") and pkg_resources.evaluate_marker(key[1:]):
-                install_requires.extend(value)
-except Exception:
-    logging.getLogger(__name__).exception(
-        "Something went wrong calculating platform specific dependencies, so "
-        "you're getting them all!"
-    )
-    for key, value in extras_require.items():
-        if key.startswith(":"):
-            install_requires.extend(value)
+extras_require = {"tests": tests_require}
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
For Python 2.7, mock is a hard requirement and so should be listed in `install_requires`.

Update system requirement to the more accurate: `python_version < '3.3'`. It no longer references unsupported Python 2.6.

Alphabetize the install_requires list.