### PR TITLE
Issue 225: Connection Error message mentions Responses

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -589,8 +589,9 @@ class RequestsMock(object):
                 logger.info("request.allowed-passthru", extra={"url": request.url})
                 return _real_send(adapter, request, **kwargs)
 
-            error_msg = "Connection refused: {0} {1}".format(
-                request.method, request.url
+            error_msg = (
+                "Connection refused by Responses: {0} {1} doesn't "
+                "match Responses Mock".format(request.method, request.url)
             )
             response = ConnectionError(error_msg)
             response.request = request


### PR DESCRIPTION
Fixes #225 
Changed the message to:
1. show that the Connection was refused by Responses
2. Show that METHOD URL doesn't match with Responses Mock