### PR TITLE
setup.py: Remove test_responses.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst CHANGES LICENSE
+include test_responses.py tox.ini
 global-exclude *~

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     url="https://github.com/getsentry/responses",
     license="Apache 2.0",
     long_description=open("README.rst").read(),
-    py_modules=["responses", "test_responses"],
+    py_modules=["responses"],
     zip_safe=False,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=install_requires,


### PR DESCRIPTION
test_responses.py is moved to MANIFEST.in to be included
in the sdist, without being an installation target.

Fixes https://github.com/getsentry/responses/issues/256