### PR TITLE
Allow extra options to the `add_callback` API

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -543,9 +543,20 @@ class RequestsMock(object):
         content_type="text/plain",
         **kwargs
     ):
-        # ensure the url has a default path set if the url is a string
-        # url = _ensure_url_default_path(url, match_querystring)
+        """
+        Register a callback to provide a dynamic response. The callback should
+        return a tuple of ``(status, headers, body)``.
 
+        >>> responses.add_callback(responses.GET, 'http://example.com', request_callback)
+
+        You can also pass a compiled regex to match multiple URLs.
+
+        >>> responses.add_callback(
+        >>>     responses.POST,
+        >>>     re.compile('http://calc.com/(sum|prod|pow|unsupported)'),
+        >>>     callback=request_callback,
+        >>> )
+        """
         self._matches.append(
             CallbackResponse(
                 url=url,

--- a/responses.py
+++ b/responses.py
@@ -534,7 +534,14 @@ class RequestsMock(object):
         self._matches[index] = response
 
     def add_callback(
-        self, method, url, callback, match_querystring=False, content_type="text/plain"
+        self,
+        method,
+        url,
+        callback,
+        match_querystring=False,
+        stream=False,
+        content_type="text/plain",
+        **kwargs
     ):
         # ensure the url has a default path set if the url is a string
         # url = _ensure_url_default_path(url, match_querystring)
@@ -544,8 +551,10 @@ class RequestsMock(object):
                 url=url,
                 method=method,
                 callback=callback,
-                content_type=content_type,
                 match_querystring=match_querystring,
+                stream=stream,
+                content_type=content_type,
+                **kwargs
             )
         )
 

--- a/responses.py
+++ b/responses.py
@@ -539,8 +539,8 @@ class RequestsMock(object):
         url,
         callback,
         match_querystring=False,
-        stream=False,
         content_type="text/plain",
+        stream=False,
         **kwargs
     ):
         """

--- a/test_responses.py
+++ b/test_responses.py
@@ -439,8 +439,8 @@ def test_callback_args():
             method="method",
             callback="callback",
             match_querystring="match_querystring",
-            stream="stream",
             content_type="content_type",
+            stream="stream",
             butter="nope",
             jelly="yes please",
         )
@@ -451,8 +451,8 @@ def test_callback_args():
         assert kwargs["method"] == "method"
         assert kwargs["callback"] == "callback"
         assert kwargs["match_querystring"] == "match_querystring"
-        assert kwargs["stream"] == "stream"
         assert kwargs["content_type"] == "content_type"
+        assert kwargs["stream"] == "stream"
 
         assert kwargs["butter"] == "nope"
         assert kwargs["jelly"] == "yes please"

--- a/test_responses.py
+++ b/test_responses.py
@@ -430,6 +430,37 @@ def test_callback():
     assert_reset()
 
 
+def test_callback_args():
+    @patch("responses.CallbackResponse")
+    @responses.activate
+    def run(mock_response):
+        responses.add_callback(
+            url="url",
+            method="method",
+            callback="callback",
+            match_querystring="match_querystring",
+            stream="stream",
+            content_type="content_type",
+            butter="nope",
+            jelly="yes please",
+        )
+
+        call = mock_response.mock_calls[0]
+        kwargs = call[2]
+        assert kwargs["url"] == "url"
+        assert kwargs["method"] == "method"
+        assert kwargs["callback"] == "callback"
+        assert kwargs["match_querystring"] == "match_querystring"
+        assert kwargs["stream"] == "stream"
+        assert kwargs["content_type"] == "content_type"
+
+        assert kwargs["butter"] == "nope"
+        assert kwargs["jelly"] == "yes please"
+
+    run()
+    assert_reset()
+
+
 def test_callback_exception_result():
     result = Exception()
     url = "http://example.com/"


### PR DESCRIPTION
Adds and passes `kwargs` through to the underlying `CallbackResponse` object.

Closes #228 
Doing the same as #241 but includes a test
