### PR TITLE
Return quoted value consistently

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -104,6 +104,14 @@ def _is_redirect(response):
         )
 
 
+def _ensure_str(s):
+    if six.PY2:
+        s = s.encode("utf-8") if isinstance(s, unicode) else s
+    if not isinstance(s, str):
+        raise TypeError("%r is not str" % s)
+    return s
+
+
 def _cookies_from_headers(headers):
     try:
         import http.cookies as cookies
@@ -115,8 +123,10 @@ def _cookies_from_headers(headers):
     except ImportError:
         from cookies import Cookies
 
-        resp_cookies = Cookies.from_request(headers["set-cookie"])
-        cookies_dict = {v.name: v.value for _, v in resp_cookies.items()}
+        resp_cookies = Cookies.from_request(_ensure_str(headers["set-cookie"]))
+        cookies_dict = {
+            v.name: quote(_ensure_str(v.value)) for _, v in resp_cookies.items()
+        }
     return cookiejar_from_dict(cookies_dict)
 
 

--- a/responses.py
+++ b/responses.py
@@ -107,8 +107,6 @@ def _is_redirect(response):
 def _ensure_str(s):
     if six.PY2:
         s = s.encode("utf-8") if isinstance(s, six.text_type) else s
-    if not isinstance(s, str):
-        raise TypeError("%r is not str" % s)
     return s
 
 

--- a/responses.py
+++ b/responses.py
@@ -106,7 +106,7 @@ def _is_redirect(response):
 
 def _ensure_str(s):
     if six.PY2:
-        s = s.encode("utf-8") if isinstance(s, unicode) else s
+        s = s.encode("utf-8") if isinstance(s, six.text_type) else s
     if not isinstance(s, str):
         raise TypeError("%r is not str" % s)
     return s

--- a/test_responses.py
+++ b/test_responses.py
@@ -922,3 +922,18 @@ def test_custom_target(monkeypatch):
     requests_mock.start()
     assert len(patch_mock.call_args_list) == 1
     assert patch_mock.call_args[1]["target"] == "something.else"
+
+
+def _quote(s):
+    return responses.quote(responses._ensure_str(s))
+
+
+def test_cookies_from_headers():
+    text = "こんにちは/世界"
+    quoted_text = _quote(text)
+    expected = {"x": "a", "y": quoted_text}
+    headers = {"set-cookie": "; ".join(k + "=" + v for k, v in expected.items())}
+    cookiejar = responses._cookies_from_headers(headers)
+    for k, v in cookiejar.items():
+        assert isinstance(v, str)
+        assert v == expected[k]


### PR DESCRIPTION
This PR normalizes the return value of `_cookies_from_headers()` so that the function consistently returns URL-quoted version of non-ASCII characters set as cookie values.

The issue is that when a cookie value involves non-ASCII chars being URL-quoted, `cookies.Cookies.from_request()` appears to return unquoted chars whereas `http.cookies.SimpleCookie.load` does not. This inconsistency makes it tedious to write tests on cookies with non-ASCII characters.