### PR TITLE
Handle cookie attributes correctly (issue #120)

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -13,7 +13,6 @@ from requests.adapters import HTTPAdapter
 from requests.cookies import RequestsCookieJar
 from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
-from requests.utils import cookiejar_from_dict
 
 try:
     from collections.abc import Sequence, Sized

--- a/responses.py
+++ b/responses.py
@@ -10,6 +10,7 @@ import six
 from collections import namedtuple
 from functools import update_wrapper
 from requests.adapters import HTTPAdapter
+from requests.cookies import RequestsCookieJar
 from requests.exceptions import ConnectionError
 from requests.sessions import REDIRECT_STATI
 from requests.utils import cookiejar_from_dict
@@ -117,7 +118,11 @@ def _cookies_from_headers(headers):
         resp_cookie = cookies.SimpleCookie()
         resp_cookie.load(headers["set-cookie"])
 
-        cookies_dict = {name: v.value for name, v in resp_cookie.items()}
+        cookie_jar = RequestsCookieJar()
+        cookie_jar.update(resp_cookie.items())
+
+        return cookie_jar
+
     except ImportError:
         from cookies import Cookies
 
@@ -125,7 +130,8 @@ def _cookies_from_headers(headers):
         cookies_dict = {
             v.name: quote(_ensure_str(v.value)) for _, v in resp_cookies.items()
         }
-    return cookiejar_from_dict(cookies_dict)
+
+        return cookiejar_from_dict(cookies_dict)
 
 
 _wrapper_template = """\

--- a/responses.py
+++ b/responses.py
@@ -113,10 +113,12 @@ def _ensure_str(s):
 def _cookies_from_headers(headers):
     try:
         import http.cookies as cookies
+
         cookie_text = headers["set-cookie"]
 
     except ImportError:
         import Cookie as cookies
+
         cookie_text = _ensure_str(headers["set-cookie"])
 
     resp_cookie = cookies.SimpleCookie()

--- a/responses.py
+++ b/responses.py
@@ -114,12 +114,14 @@ def _ensure_str(s):
 def _cookies_from_headers(headers):
     try:
         import http.cookies as cookies
+        cookie_text = headers["set-cookie"]
 
     except ImportError:
         import Cookie as cookies
+        cookie_text = _ensure_str(headers["set-cookie"])
 
     resp_cookie = cookies.SimpleCookie()
-    resp_cookie.load(headers["set-cookie"])
+    resp_cookie.load(cookie_text)
 
     cookie_jar = RequestsCookieJar()
     cookie_jar.update(resp_cookie.items())

--- a/responses.py
+++ b/responses.py
@@ -115,23 +115,16 @@ def _cookies_from_headers(headers):
     try:
         import http.cookies as cookies
 
-        resp_cookie = cookies.SimpleCookie()
-        resp_cookie.load(headers["set-cookie"])
-
-        cookie_jar = RequestsCookieJar()
-        cookie_jar.update(resp_cookie.items())
-
-        return cookie_jar
-
     except ImportError:
-        from cookies import Cookies
+        import Cookie as cookies
 
-        resp_cookies = Cookies.from_request(_ensure_str(headers["set-cookie"]))
-        cookies_dict = {
-            v.name: quote(_ensure_str(v.value)) for _, v in resp_cookies.items()
-        }
+    resp_cookie = cookies.SimpleCookie()
+    resp_cookie.load(headers["set-cookie"])
 
-        return cookiejar_from_dict(cookies_dict)
+    cookie_jar = RequestsCookieJar()
+    cookie_jar.update(resp_cookie.items())
+
+    return cookie_jar
 
 
 _wrapper_template = """\

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,7 @@ setup_requires = []
 if "test" in sys.argv:
     setup_requires.append("pytest")
 
-install_requires = [
-    "mock; python_version < '3.3'",
-    "requests>=2.0",
-    "six",
-]
+install_requires = ["mock; python_version < '3.3'", "requests>=2.0", "six"]
 
 tests_require = [
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ if "test" in sys.argv:
     setup_requires.append("pytest")
 
 install_requires = [
-    "cookies; python_version < '3.4'",
     "mock; python_version < '3.3'",
     "requests>=2.0",
     "six",

--- a/test_responses.py
+++ b/test_responses.py
@@ -941,7 +941,15 @@ def test_cookies_from_headers():
 def test_cookie_attribute_handling():
     expected_domains = ['.stackoverflow.com']
     expected_paths = ['/']
-    headers = {'set-cookie': 'prov=c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx; domain=.stackoverflow.com; expires=Fri, 01-Jan-2055 00:00:00 GMT; path=/; HttpOnly'}
+    cookie_attributes = {
+        "prov": "c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx",
+        "domain": ".stackoverflow.com",
+        "expires": "Fri, 01-Jan-2055 00:00:00 GMT",
+        "path": "/",
+    }
+    cookie_text = "; ".join(k + "=" + v for k,v in cookie_attributes.items())
+    cookie_text = cookie_text + "; HttpOnly"
+    headers = {'set-cookie': cookie_text}
     cookiejar = responses._cookies_from_headers(headers)
     assert cookiejar.list_domains() == expected_domains
     assert cookiejar.list_paths() == expected_paths

--- a/test_responses.py
+++ b/test_responses.py
@@ -938,18 +938,19 @@ def test_cookies_from_headers():
         assert isinstance(v, str)
         assert v == expected[k]
 
+
 def test_cookie_attribute_handling():
-    expected_domains = ['.stackoverflow.com']
-    expected_paths = ['/']
-    cookie_attributes = {
-        "prov": "c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx",
-        "domain": ".stackoverflow.com",
-        "expires": "Fri, 01-Jan-2055 00:00:00 GMT",
-        "path": "/",
-    }
-    cookie_text = "; ".join(k + "=" + v for k,v in cookie_attributes.items())
-    cookie_text = cookie_text + "; HttpOnly"
-    headers = {'set-cookie': cookie_text}
+    expected_domains = [".stackoverflow.com"]
+    expected_paths = ["/"]
+    cookie_attributes = [
+        "prov=c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx",
+        "domain=.stackoverflow.com",
+        "expires=Fri, 01-Jan-2055 00:00:00 GMT",
+        "path=/",
+        "HttpOnly",
+    ]
+    cookie_text = "; ".join(cookie_attributes)
+    headers = {"set-cookie": cookie_text}
     cookiejar = responses._cookies_from_headers(headers)
     assert cookiejar.list_domains() == expected_domains
     assert cookiejar.list_paths() == expected_paths

--- a/test_responses.py
+++ b/test_responses.py
@@ -937,3 +937,12 @@ def test_cookies_from_headers():
     for k, v in cookiejar.items():
         assert isinstance(v, str)
         assert v == expected[k]
+
+def test_cookie_attribute_handling():
+    expected_domains = ['.stackoverflow.com']
+    expected_paths = ['/']
+    headers = {'set-cookie': 'prov=c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx; domain=.stackoverflow.com; expires=Fri, 01-Jan-2055 00:00:00 GMT; path=/; HttpOnly'}
+    cookiejar = responses._cookies_from_headers(headers)
+    assert cookiejar.list_domains() == expected_domains
+    assert cookiejar.list_paths() == expected_paths
+    


### PR DESCRIPTION
#120 

Cookies added through `adding-headers` would not be parsed correctly if they included `;` characters. `;` characters are treated as separators of cookies, rather than separators of the cookie attributes.

Previously:

```
Python 3.7.3 (default, Jun 24 2019, 04:54:02) 
[GCC 9.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests, responses
>>> @responses.activate
... def test():
...     responses.add(responses.GET, 'http://stackoverflow.com', adding_headers={'Set-Cookie': 'prov=c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx; domain=.stackoverflow.com; expires=Fri
, 01-Jan-2055 00:00:00 GMT; path=/; HttpOnly'})
...     return requests.get('http://stackoverflow.com').cookies
... 
>>> cookies = test()
>>> cookies
<RequestsCookieJar[Cookie(version=0, name='prov', value='c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx', port=None, port_specified=False, domain='', domain_specified=False, domain_initial_dot=False, path='/', path_specified=True, secure=False, expires=None, discard=True, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False)]>
>>>
```

After this PR:

```
Python 3.7.3 (default, Jun 24 2019, 04:54:02) 
[GCC 9.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests, responses
>>> @responses.activate
... def test():
...     responses.add(responses.GET, 'http://stackoverflow.com', adding_headers={'Set-Cookie': 'prov=c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx; domain=.stackoverflow.com; expires=Fri
, 01-Jan-2055 00:00:00 GMT; path=/; HttpOnly'})
...     return requests.get('http://stackoverflow.com').cookies
... 
>>> cookies = test()
>>> cookies
<RequestsCookieJar[Cookie(version=0, name='prov', value='c83dc7dc-e0b9-xxxx-xxxx-xxxxxxxxxxxx', port=None, port_specified=False, domain='.stackoverflow.com', domain_specified=True, domain_initial_dot=True, path='/', path_specified=True, secure=False, expires=2682374400, discard=False, comment='', comment_url=False, rest={'HttpOnly': True}, rfc2109=False)]>
```

Note the changed attributes in the resultant `RequestsCookieJar` object.