### PR TITLE
Fix testcase test_assert_all_requests_are_fired failure

### DIFF
--- a/test_responses.py
+++ b/test_responses.py
@@ -701,7 +701,7 @@ def test_assert_all_requests_are_fired():
             with responses.RequestsMock(assert_all_requests_are_fired=True) as m:
                 m.add(responses.GET, "http://example.com", body=b"test")
         assert "http://example.com" in str(excinfo.value)
-        assert responses.GET in str(excinfo)
+        assert responses.GET in str(excinfo.value)
 
         # check that assert_all_requests_are_fired default to True
         with pytest.raises(AssertionError):


### PR DESCRIPTION
Pytest 5.0.0 changed ExceptionInfo object's str() to returns the same as repr().
(See, item #5412 of https://docs.pytest.org/en/latest/changelog.html#pytest-5-0-0-2019-06-28)
This patch fixes the test failure by comparing expectation with str() result of
ExceptionInfo's value member instead of object itself.

Signed-off-by: Brandon Hong <brandon.hong@intel.com>