### PR TITLE
Fix tests on Python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ install_requires = [
 ]
 
 tests_require = [
-    "pytest",
+    "pytest==4.6; python_version < '3.5'",
+    "pytest; python_version >= '3.5'",
     "coverage >= 3.7.1, < 5.0.0",
     "pytest-cov",
     "pytest-localserver",


### PR DESCRIPTION
pytest after 4.6 does not support Python 3.5 and earlier, causing tests run under Python 2.7 to fail with syntax errors in pytest.  Update the pytest requirement to use the appropriate version depending on the version of Python in use.