### PR TITLE
Update pytest requirements to allow for 4.6 point releases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,7 @@
     "python.linting.flake8Enabled": true,
     "python.formatting.provider": "black",
     "python.pythonPath": "${env.WORKON_HOME}/responses/bin/python",
-    "python.unitTest.pyTestEnabled": false,
-    "python.unitTest.unittestEnabled": false,
-    "python.unitTest.nosetestsEnabled": false
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false
 }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
 ]
 
 tests_require = [
-    "pytest==4.6; python_version < '3.5'",
+    "pytest>=4.6,<5.0; python_version < '3.5'",
     "pytest; python_version >= '3.5'",
     "coverage >= 3.7.1, < 5.0.0",
     "pytest-cov",


### PR DESCRIPTION
The fix in #284 does not allow for point releases of pytest 4.6 to be installed, only 4.6.0.

According to [pytest.org](https://pytest.org/en/latest/py27-py34-deprecation.html):

> until January 2020 the pytest core team plans to make bug-fix releases of the pytest 4.6 series by back-porting patches to the 4.6-maintenance branch that affect Python 2 users.
> 
> After 2020, the core team will no longer actively backport patches, but the 4.6-maintenance branch will continue to exist so the community itself can contribute patches. The core team will be happy to accept those patches and make new 4.6 releases until mid-2020.

So pytest 4.6 will continue to receive patches for Python 2 support even past mid-2020, just not by the core contributors.

This allows for pytest of any version less than 5.0 for `python_version < 3.5`.

Also, it appears that the [configuration keys for vscode's python testing](https://code.visualstudio.com/docs/python/testing#_test-configuration-settings) have changed, so this adds those, automatically fixed by my VSCode.