### PR TITLE
Update required version of requests to >=2.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 - '3.7'
@@ -13,7 +12,7 @@ cache:
   - ".pip_download_cache"
 env:
   matrix:
-  - REQUESTS="requests>=2.0,<3.0"
+  - REQUESTS="requests>=2.22.0,<3.0"
   - REQUESTS="-U requests"
   - REQUESTS="-e git+git://github.com/requests/requests.git#egg=requests"
   global:

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ A utility library for mocking out the `requests` Python library.
 
 ..  note::
 
-    Responses requires Python 2.7 or newer, and requests >= 2.0
+    Responses requires Python 2.7 or newer, and requests >= 2.22.0
 
 
 Installing

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if "test" in sys.argv:
 install_requires = [
     "cookies; python_version < '3.4'",
     "mock; python_version < '3.3'",
-    "requests>=2.0",
+    "requests>=2.22.0",
     "six",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     long_description_content_type="text/x-rst",
     py_modules=["responses"],
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=install_requires,
     extras_require=extras_require,
     tests_require=tests_require,


### PR DESCRIPTION
Thank you for taking the time to review my PR!

### Summary
* Required version of requests is now `>=2.22.0`
* Required Python versions match requests version `2.22.0` (i.e. no more Python 3.4)
* Updates README to reflect this

### Motivation

If you have an earlier version of requests installed, you'll see a ` TypeError: __init__() got an unexpected keyword argument 'msg'` when calling `get_response`.

#### Cause of the TypeError
As of version 0.10.8 ([relevant diff](https://github.com/getsentry/responses/commit/a9dab5b1fa896c56ddf4fd057f116ead740f74f0#diff-9206e1daa98d75bd8b5c902a12aa5ea5R384)), `get_response` constructs an original `HTTPResponse` object with headers as the `msg`. However, the  `msg` argument for `HTTPResponse` was only introduced in urllib3 version 1.25.7 ([relevant diff](https://github.com/urllib3/urllib3/commit/bdacb3f975a4ec460904477f5c6ce050bebf44dd#diff-01955f24bc4d0d621454698a584ab854L115)).

That version of urllib3 is only supported as of version 2.22.0 of requests- before that release, it was pinned to <1.25 ([relevant diff](https://github.com/psf/requests/commit/aeda65bbe57ac5edbcc2d80db85d010befb7d419#diff-2eeaed663bd0d25b7e608891384b7298R47)). I also had to update `python_requires` to match this version of requests ([relevant line](https://github.com/psf/requests/commit/aeda65bbe57ac5edbcc2d80db85d010befb7d419#diff-2eeaed663bd0d25b7e608891384b7298R82)).

### Notes
I was tempted to pin to an exact version of requests, but that seemed like a larger change that should probably be determined by someone with more context on the project.