### PR TITLE
Remove tests for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ language: python
 sudo: false
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 - '3.7'
 - nightly
+
 cache:
   directories:
   - ".pip_download_cache"
+
 env:
   matrix:
   - REQUESTS="requests>=2.0,<3.0"
@@ -18,19 +19,23 @@ env:
   - REQUESTS="-e git+git://github.com/requests/requests.git#egg=requests"
   global:
   - PIP_DOWNLOAD_CACHE=".pip_download_cache"
+
 matrix:
   allow_failures:
   - env: REQUESTS="-e git+git://github.com/requests/requests.git#egg=requests"
   - python: nightly
+
 install:
 - pip install codecov
 - pip install ${REQUESTS}
 - make install-deps
+
 script:
 - make
 - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pre-commit run -a -v; fi
 - pytest . --cov-report term-missing  --cov . --cov-report="xml:.artifacts/coverage.xml"
   --junit-xml=".artifacts/junit.xml"
+
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"
@@ -40,17 +45,20 @@ deploy:
     secure: SejRAkh567ae8HNgLMWebpPwOxn2+wfrKWHkm8JTmCJcxKIQmfbPlUJPAspJ9HF7kBB1MzkkqNkXG184VEgH1l1JqUNyZKqrk+y4R3s+jjJ+Yqepm3SeAiq5FceS8BwCegO9L3po299NtdWFHllydVLLL+Rf3ZnCQOl5YT1tzzk=
   on:
     tags: true
+
 after_success:
 - codecov -e REQUESTS -e TRAVIS_PYTHON_VERSION
 - npm install -g @zeus-ci/cli
 - zeus upload -t "text/x-pycodestyle" .artifacts/flake8.log
 - zeus upload -t "text/xml+xunit" .artifacts/*junit.xml
 - zeus upload -t "text/xml+coverage" .artifacts/*coverage.xml
+
 after_failure:
 - npm install -g @zeus-ci/cli
 - zeus upload -t "text/x-pycodestyle" .artifacts/flake8.log
 - zeus upload -t "text/xml+xunit" .artifacts/*junit.xml
 - zeus upload -t "text/xml+coverage" .artifacts/*coverage.xml
+
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
The pre-commit dependencies no longer install in python 3.4. Python3.4
is pretty old and has low usage as well.