### PR TITLE
Improve ConnectionError message

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -640,9 +640,15 @@ class RequestsMock(object):
                 return _real_send(adapter, request, **kwargs)
 
             error_msg = (
-                "Connection refused by Responses: {0} {1} doesn't "
-                "match Responses Mock".format(request.method, request.url)
+                "Connection refused by Responses - the call doesn't "
+                "match any registered mock.\n\n"
+                "Request: \n"
+                "- {0} {1}\n\n"
+                "Available matches:\n".format(request.method, request.url)
             )
+            for m in self._matches:
+                error_msg += "- {} {}\n".format(m.method, m.url)
+
             response = ConnectionError(error_msg)
             response.request = request
 

--- a/responses.py
+++ b/responses.py
@@ -640,14 +640,14 @@ class RequestsMock(object):
                 return _real_send(adapter, request, **kwargs)
 
             error_msg = (
-                "Connection refused by Responses - the call doesn't "
+                u"Connection refused by Responses - the call doesn't "
                 "match any registered mock.\n\n"
                 "Request: \n"
                 "- {0} {1}\n\n"
                 "Available matches:\n".format(request.method, request.url)
             )
             for m in self._matches:
-                error_msg += "- {} {}\n".format(m.method, m.url)
+                error_msg += u"- {} {}\n".format(m.method, m.url)
 
             response = ConnectionError(error_msg)
             response.request = request


### PR DESCRIPTION
When a request doesn't match the responses mock the error message isn't
very helpful. It tells you the request that was made which doesn't match
any mock, but it doesn't show you what responses have been registered.

This PR shows the request that has been made together with registered
responses. It makes it easier to spot why a test is failing because you
can compare the request with the mocks side by side.

Prior output:
```
requests.exceptions.ConnectionError: Connection refused by Responses: GET https://graph.facebook.com/v5.0/search?access_token=testac&type=adinterestvalid&interest_fbid_list=%5B%22123%22%5D doesn't match Responses Mock
```

New output:
```
requests.exceptions.ConnectionError: Connection refused by Responses - the call doesn't match any registered mock.

Request:
-GET https://graph.facebook.com/v5.0/search?access_token=testac&type=adinterestvalid&interest_fbid_list=%5B%22123%22%5D

Available matches:
-  GET https://graph.facebook.com/v5.0/me/adaccounts?access_token=testac&summary=true
- GET https://graph.facebook.com/v5.0//search?access_token=testac&type=adinterestvalid&interest_fbid_list=%5B%22123%22%5D
```