### PR TITLE
Fixed formating in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,7 @@ a callback function to give a slightly different result, you can use ``functools
         )
 
 
-You can see params passed in the original ‍‍``request`` in ‍‍``responses.calls[].request.params``:
+You can see params passed in the original ``request`` in ``responses.calls[].request.params``:
 
 .. code-block:: python
 


### PR DESCRIPTION
Now the line contains (``) by mistake:
```
You can see params passed in the original ‍‍``request`` in ‍‍``responses.calls[].request.params``:
```
This patch fixed the formating. Here is the real diff:

```diff
-You can see params passed in the original <U+200D><U+200D>``request`` in <U+200D><U+200D>``responses.calls[].request.params``:
+You can see params passed in the original ``request`` in ``responses.calls[].request.params``:
```
