### PR TITLE
Improve code coverage

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -270,17 +270,7 @@ class BaseResponse(object):
         url_qsl = sorted(parse_qsl(url_parsed.query))
         other_qsl = sorted(parse_qsl(other_parsed.query))
 
-        if len(url_qsl) != len(other_qsl):
-            return False
-
-        for (a_k, a_v), (b_k, b_v) in zip(url_qsl, other_qsl):
-            if a_k != b_k:
-                return False
-
-            if a_v != b_v:
-                return False
-
-        return True
+        return url_qsl == other_qsl
 
     def _should_match_querystring(self, match_querystring_argument):
         if match_querystring_argument is not _unspecified:

--- a/test_responses.py
+++ b/test_responses.py
@@ -334,6 +334,20 @@ def test_match_querystring_auto_activates():
     assert_reset()
 
 
+def test_match_querystring_missing_key():
+    @responses.activate
+    def run():
+        responses.add(responses.GET, "http://example.com?foo=1&bar=2", body=b"test")
+        with pytest.raises(ConnectionError):
+            requests.get("http://example.com/?foo=1&baz=2")
+
+        with pytest.raises(ConnectionError):
+            requests.get("http://example.com/?bar=2&fez=1")
+
+    run()
+    assert_reset()
+
+
 def test_accept_string_body():
     @responses.activate
     def run():

--- a/test_responses.py
+++ b/test_responses.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 import inspect
 import re
 import six
+from io import BufferedReader, BytesIO
 
 import pytest
 import requests
@@ -914,6 +915,21 @@ def test_handles_unicode_url():
     @responses.activate
     def run():
         responses.add(responses.GET, url, body="test")
+
+        resp = requests.get(url)
+
+        assert_response(resp, "test")
+
+    run()
+    assert_reset()
+
+
+def test_handles_buffered_reader_body():
+    url = "http://example.com/test"
+
+    @responses.activate
+    def run():
+        responses.add(responses.GET, url, body=BufferedReader(BytesIO(b"test")))
 
         resp = requests.get(url)
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -985,6 +985,21 @@ def test_multiple_urls():
     assert_reset()
 
 
+def test_multiple_methods():
+    @responses.activate
+    def run():
+        responses.add(responses.GET, "http://example.com/one", body="gotcha")
+        responses.add(responses.POST, "http://example.com/one", body="posted")
+
+        resp = requests.get("http://example.com/one")
+        assert_response(resp, "gotcha")
+        resp = requests.post("http://example.com/one")
+        assert_response(resp, "posted")
+
+    run()
+    assert_reset()
+
+
 def test_passthru(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 


### PR DESCRIPTION
Was looking over the code coverage report and added some missing test cases:

* `BaseResponse.matches()` distinguishing on method
* `BaseResponse._url_matches_strict()` when the number of params is the same but the keys don't match
* `_handle_body()` when the body is a BufferedReader from opening a file handle

The third commit here actually simplifies the comparison in `BaseResponse._url_matches_strict()` to a straight list comparison - it doesn't make sense to compare length and then directly compare the contents of the tuples, unless this is leftover from some old dict comparison code?