### PR TITLE
Fix bug in handling unicode body

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -355,11 +355,10 @@ class Response(BaseResponse):
                 content_type = "application/json"
 
         if content_type is UNSET:
-            content_type = "text/plain"
-
-        # body must be bytes
-        if isinstance(body, six.text_type):
-            body = body.encode("utf-8")
+            if isinstance(body, six.text_type) and _has_unicode(body):
+                content_type = "text/plain; charset=utf-8"
+            else:
+                content_type = "text/plain"
 
         self.body = body
         self.status = status

--- a/test_responses.py
+++ b/test_responses.py
@@ -909,6 +909,21 @@ def test_handles_unicode_url():
     assert_reset()
 
 
+def test_handles_unicode_body():
+    url = "http://example.com/test"
+
+    @responses.activate
+    def run():
+        responses.add(responses.GET, url, body="михољско лето")
+
+        resp = requests.get(url)
+
+        assert_response(resp, "михољско лето", content_type="text/plain; charset=utf-8")
+
+    run()
+    assert_reset()
+
+
 def test_headers():
     @responses.activate
     def run():


### PR DESCRIPTION
Added a test to return a unicode body and noticed this wasn't working as
the charset wasn't being set. This also highlighted that Response
converts unicode to bytes twice, once in the constructor and once in the
call to _handle_body(), so the conversion in the constructor has been
removed.

There's possibly a similar bug in CallbackResponse too.