### PR TITLE
Fix params parsing

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -622,7 +622,7 @@ class RequestsMock(object):
     def _on_request(self, adapter, request, **kwargs):
         match = self._find_match(request)
         resp_callback = self.response_callback
-        request.params = dict(parse_qsl(request.path_url.replace("/?", "")))
+        request.params = dict(parse_qsl(urlparse(request.path_url).query))
 
         if match is None:
             if any(

--- a/test_responses.py
+++ b/test_responses.py
@@ -1122,21 +1122,22 @@ def test_cookies_from_headers():
         assert v == expected[k]
 
 
-def test_request_param():
+@pytest.mark.parametrize("url", ("http://example.com", "http://example.com/some/path",))
+def test_request_param(url):
     @responses.activate
     def run():
         params = {"hello": "world", "example": "params"}
         responses.add(
             method=responses.GET,
-            url="http://example.com?hello=world",
+            url="{0}?hello=world".format(url),
             body="test",
             match_querystring=False,
         )
-        resp = requests.get("http://example.com", params=params)
+        resp = requests.get(url, params=params)
         assert_response(resp, "test")
         assert resp.request.params == params
 
-        resp = requests.get("http://example.com")
+        resp = requests.get(url)
         assert_response(resp, "test")
         assert resp.request.params == {}
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -1122,7 +1122,14 @@ def test_cookies_from_headers():
         assert v == expected[k]
 
 
-@pytest.mark.parametrize("url", ("http://example.com", "http://example.com/some/path",))
+@pytest.mark.parametrize(
+    "url",
+    (
+        "http://example.com",
+        "http://example.com/some/path",
+        "http://example.com/other/path/",
+    ),
+)
 def test_request_param(url):
     @responses.activate
     def run():


### PR DESCRIPTION
Using a simple replace when parsing the params results in an error when there's some path present.
For example, without this fix the new test would break with something like:
```python
AssertionError:
    {'/some/path?hello': 'world', 'example': 'params'}
    {'example': 'params', 'hello': 'world'}
```