### PR TITLE
Add post params with custom matchers

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -247,7 +247,7 @@ def json_params_matcher(params):
             if isinstance(request_body, bytes):
                 request_body = request_body.decode("utf-8")
             return params == json_module.loads(request_body)
-        except JSONDecodeError as err:
+        except JSONDecodeError:
             return False
 
     return match

--- a/responses.py
+++ b/responses.py
@@ -244,6 +244,8 @@ def urlencoded_params_matcher(params):
 def json_params_matcher(params):
     def match(request_body):
         try:
+            if isinstance(request_body, bytes):
+                request_body = request_body.decode("utf-8")
             return params == json_module.loads(request_body)
         except JSONDecodeError as err:
             return False

--- a/responses.py
+++ b/responses.py
@@ -235,11 +235,12 @@ class BaseResponse(object):
 
     stream = False
 
-    def __init__(self, method, url, match_querystring=_unspecified):
+    def __init__(self, method, url, match_querystring=_unspecified, post_params=None):
         self.method = method
         # ensure the url has a default path set if the url is a string
         self.url = _ensure_url_default_path(url)
         self.match_querystring = self._should_match_querystring(match_querystring)
+        self.post_params = post_params
         self.call_count = 0
 
     def __eq__(self, other):
@@ -302,6 +303,12 @@ class BaseResponse(object):
         else:
             return False
 
+    def _post_params_match(self, post_params, request_body, content_type):
+        if post_params == None:
+            return True
+
+        return sorted(post_params.items()) == sorted(parse_qsl(request_body))
+
     def get_headers(self):
         headers = HTTPHeaderDict()  # Duplicate headers are legal
         if self.content_type is not None:
@@ -318,6 +325,9 @@ class BaseResponse(object):
             return False
 
         if not self._url_matches(self.url, request.url, self.match_querystring):
+            return False
+
+        if not self._post_params_match(self.post_params, request.body, self.content_type):
             return False
 
         return True

--- a/responses.py
+++ b/responses.py
@@ -53,6 +53,11 @@ except AttributeError:
     # Python 3.7
     Pattern = re.Pattern
 
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 UNSET = object()
 
 Call = namedtuple("Call", ["request", "response"])
@@ -240,7 +245,7 @@ def json_params_matcher(params):
     def match(request_body):
         try:
             return params == json_module.loads(request_body)
-        except json_module.decoder.JSONDecodeError as err:
+        except JSONDecodeError as err:
             return False
 
     return match

--- a/responses.py
+++ b/responses.py
@@ -304,7 +304,7 @@ class BaseResponse(object):
             return False
 
     def _post_params_match(self, post_params, request_body, content_type):
-        if post_params == None:
+        if post_params is None:
             return True
 
         return sorted(post_params.items()) == sorted(parse_qsl(request_body))
@@ -327,7 +327,9 @@ class BaseResponse(object):
         if not self._url_matches(self.url, request.url, self.match_querystring):
             return False
 
-        if not self._post_params_match(self.post_params, request.body, self.content_type):
+        if not self._post_params_match(
+            self.post_params, request.body, self.content_type
+        ):
             return False
 
         return True

--- a/test_responses.py
+++ b/test_responses.py
@@ -1030,7 +1030,6 @@ def test_multiple_methods():
     run()
     assert_reset()
 
-
 def test_passthru(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
@@ -1049,7 +1048,6 @@ def test_passthru(httpserver):
 
     run()
     assert_reset()
-
 
 def test_passthru_regex(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
@@ -1181,6 +1179,40 @@ def test_assert_call_count(url):
         assert "Expected URL '{0}' to be called 3 times. Called 2 times.".format(
             url
         ) in str(excinfo.value)
+
+    run()
+    assert_reset()
+
+def test_request_matches_post_params():
+    @responses.activate
+    def run():
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="one",
+            post_params={"page": "first"}
+        )
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="two",
+            post_params={"page": "second"}
+        )
+
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={'Content-Type': 'application/json'},
+            data={"page": "second"}
+        )
+        assert_response(resp, "two")
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={'Content-Type': 'application/json'},
+            data={"page": "first"}
+        )
+        assert_response(resp, "one")
 
     run()
     assert_reset()

--- a/test_responses.py
+++ b/test_responses.py
@@ -1193,17 +1193,21 @@ def test_request_matches_post_params():
             method=responses.POST,
             url="http://example.com/",
             body="one",
-            post_params_matcher=responses.json_params_matcher(
-                {"page": {"name": "first", "type": "json"}}
-            ),
+            match=[
+                responses.json_params_matcher(
+                    {"page": {"name": "first", "type": "json"}}
+                )
+            ],
         )
         responses.add(
             method=responses.POST,
             url="http://example.com/",
             body="two",
-            post_params_matcher=responses.urlencoded_params_matcher(
-                {"page": "second", "type": "urlencoded"}
-            ),
+            match=[
+                responses.urlencoded_params_matcher(
+                    {"page": "second", "type": "urlencoded"}
+                )
+            ],
         )
 
         resp = requests.request(

--- a/test_responses.py
+++ b/test_responses.py
@@ -1194,7 +1194,7 @@ def test_request_matches_post_params():
             url="http://example.com/",
             body="one",
             post_params_matcher=responses.json_params_matcher(
-                {"page": {"name": "first", "type": "json",}}
+                {"page": {"name": "first", "type": "json"}}
             ),
         )
         responses.add(
@@ -1218,7 +1218,7 @@ def test_request_matches_post_params():
             "POST",
             "http://example.com/",
             headers={"Content-Type": "application/json"},
-            json={"page": {"name": "first", "type": "json",}},
+            json={"page": {"name": "first", "type": "json"}},
         )
         assert_response(resp, "one")
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -1030,6 +1030,7 @@ def test_multiple_methods():
     run()
     assert_reset()
 
+
 def test_passthru(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
@@ -1048,6 +1049,7 @@ def test_passthru(httpserver):
 
     run()
     assert_reset()
+
 
 def test_passthru_regex(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
@@ -1183,6 +1185,7 @@ def test_assert_call_count(url):
     run()
     assert_reset()
 
+
 def test_request_matches_post_params():
     @responses.activate
     def run():
@@ -1190,27 +1193,27 @@ def test_request_matches_post_params():
             method=responses.POST,
             url="http://example.com/",
             body="one",
-            post_params={"page": "first"}
+            post_params={"page": "first"},
         )
         responses.add(
             method=responses.POST,
             url="http://example.com/",
             body="two",
-            post_params={"page": "second"}
+            post_params={"page": "second"},
         )
 
         resp = requests.request(
             "POST",
             "http://example.com/",
-            headers={'Content-Type': 'application/json'},
-            data={"page": "second"}
+            headers={"Content-Type": "application/json"},
+            data={"page": "second"},
         )
         assert_response(resp, "two")
         resp = requests.request(
             "POST",
             "http://example.com/",
-            headers={'Content-Type': 'application/json'},
-            data={"page": "first"}
+            headers={"Content-Type": "application/json"},
+            data={"page": "first"},
         )
         assert_response(resp, "one")
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -1193,27 +1193,32 @@ def test_request_matches_post_params():
             method=responses.POST,
             url="http://example.com/",
             body="one",
-            post_params={"page": "first"},
+            post_params_matcher=responses.json_params_matcher(
+                {"page": {"name": "first", "type": "json",}}
+            ),
         )
         responses.add(
             method=responses.POST,
             url="http://example.com/",
             body="two",
-            post_params={"page": "second"},
+            post_params_matcher=responses.urlencoded_params_matcher(
+                {"page": "second", "type": "urlencoded"}
+            ),
         )
 
         resp = requests.request(
             "POST",
             "http://example.com/",
-            headers={"Content-Type": "application/json"},
-            data={"page": "second"},
+            headers={"Content-Type": "x-www-form-urlencoded"},
+            data={"page": "second", "type": "urlencoded"},
         )
         assert_response(resp, "two")
+
         resp = requests.request(
             "POST",
             "http://example.com/",
             headers={"Content-Type": "application/json"},
-            data={"page": "first"},
+            json={"page": {"name": "first", "type": "json",}},
         )
         assert_response(resp, "one")
 


### PR DESCRIPTION
This approach lets users match on POSTed parameters - it includes two matchers for urlencoded and JSON encoded parameters and leaves open the possibility of matching on params encoded in other ways:

```
responses.add(
    method=responses.POST,
    url="http://example.com/",
    body="one",
    post_params_matcher=responses.json_params_matcher(
        {"page": {"name": "first", "type": "json",}}
    ),
)
responses.add(
    method=responses.POST,
    url="http://example.com/",
    body="two",
    post_params_matcher=responses.urlencoded_params_matcher(
        {"page": "second", "type": "urlencoded"}
    ),
)
```