### PR TITLE
Add post params JSON or urlencoded

### DIFF
--- a/test_responses.py
+++ b/test_responses.py
@@ -970,7 +970,6 @@ def test_multiple_urls():
     run()
     assert_reset()
 
-
 def test_passthru(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
@@ -989,7 +988,6 @@ def test_passthru(httpserver):
 
     run()
     assert_reset()
-
 
 def test_passthru_regex(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
@@ -1079,6 +1077,40 @@ def test_request_param():
         resp = requests.get("http://example.com")
         assert_response(resp, "test")
         assert resp.request.params == {}
+
+    run()
+    assert_reset()
+
+def test_request_matches_post_params():
+    @responses.activate
+    def run():
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="one",
+            post_params={"page": "first"}
+        )
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="two",
+            post_params={"page": "second"}
+        )
+
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={'Content-Type': 'application/json'},
+            data={"page": "second"}
+        )
+        assert_response(resp, "two")
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={'Content-Type': 'application/json'},
+            data={"page": "first"}
+        )
+        assert_response(resp, "one")
 
     run()
     assert_reset()

--- a/test_responses.py
+++ b/test_responses.py
@@ -1116,5 +1116,29 @@ def test_request_matches_post_params():
         )
         assert_response(resp, "one")
 
+        with pytest.raises(ConnectionError):
+            resp = requests.request(
+                "POST",
+                "http://example.com/",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={"page": {"name": "third", "type": "not present"}},
+            )
+
+        with pytest.raises(ConnectionError):
+            resp = requests.request(
+                "POST",
+                "http://example.com/",
+                headers={"Content-Type": "application/json"},
+                data="BAD JSON",
+            )
+
+        with pytest.raises(ConnectionError):
+            resp = requests.request(
+                "POST",
+                "http://example.com/",
+                headers={"Content-Type": "plain/text"},
+                data="bad content-type",
+            )
+
     run()
     assert_reset()

--- a/test_responses.py
+++ b/test_responses.py
@@ -970,6 +970,7 @@ def test_multiple_urls():
     run()
     assert_reset()
 
+
 def test_passthru(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
@@ -988,6 +989,7 @@ def test_passthru(httpserver):
 
     run()
     assert_reset()
+
 
 def test_passthru_regex(httpserver):
     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
@@ -1081,6 +1083,7 @@ def test_request_param():
     run()
     assert_reset()
 
+
 def test_request_matches_post_params():
     @responses.activate
     def run():
@@ -1088,27 +1091,28 @@ def test_request_matches_post_params():
             method=responses.POST,
             url="http://example.com/",
             body="one",
-            post_params={"page": "first"}
+            post_params={"page": {"name": "first", "type": "json"}},
         )
         responses.add(
             method=responses.POST,
             url="http://example.com/",
             body="two",
-            post_params={"page": "second"}
+            post_params={"page": "second", "type": "urlencoded"},
         )
 
         resp = requests.request(
             "POST",
             "http://example.com/",
-            headers={'Content-Type': 'application/json'},
-            data={"page": "second"}
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={"page": "second", "type": "urlencoded"},
         )
         assert_response(resp, "two")
+
         resp = requests.request(
             "POST",
             "http://example.com/",
-            headers={'Content-Type': 'application/json'},
-            data={"page": "first"}
+            headers={"Content-Type": "application/json"},
+            json={"page": {"name": "first", "type": "json"}},
         )
         assert_response(resp, "one")
 


### PR DESCRIPTION
This allows matching on POSTed parameters by passing a normal python map, and this is parsed out when a request is received based on the Content-Type of the request