### PR TITLE
Updated pytest minimum required version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
 
 tests_require = [
     "pytest>=4.6,<5.0; python_version < '3.5'",
-    "pytest; python_version >= '3.5'",
+    "pytest>=4.6; python_version >= '3.5'",
     "coverage >= 3.7.1, < 5.0.0",
     "pytest-cov",
     "pytest-localserver",


### PR DESCRIPTION
We have some failed tests in #329 with this error message:
`pkg_resources.VersionConflict: (pytest 4.3.1 (/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages), Requirement.parse('pytest>=4.6'))`

And, Here is from `pytest-cov 2.10.0`  Changelog:
`Removed legacy pytest support. Changed setup.py so that pytest>=4.6 is required.`

