### PR TITLE
Omit test files from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = test*


### PR DESCRIPTION
It actually looks like there is dead code in the tests if only 96% is the result.

In any case the coverage of the library should be what is reported.

Coverage of the library is artificially inflated from tests out of the box.

This fixes that