### PR TITLE
Add matchers for post keys

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -241,12 +241,31 @@ def urlencoded_params_matcher(params):
     return match
 
 
+def urlencoded_keys_matcher(keys):
+    def match(request_body):
+        return sorted(keys) == sorted(dict(parse_qsl(request_body)).keys())
+
+    return match
+
+
 def json_params_matcher(params):
     def match(request_body):
         try:
             if isinstance(request_body, bytes):
                 request_body = request_body.decode("utf-8")
             return params == json_module.loads(request_body)
+        except JSONDecodeError:
+            return False
+
+    return match
+
+
+def json_keys_matcher(keys):
+    def match(request_body):
+        try:
+            if isinstance(request_body, bytes):
+                request_body = request_body.decode("utf-8")
+            return sorted(keys) == sorted(json_module.loads(request_body).keys())
         except JSONDecodeError:
             return False
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -1228,3 +1228,39 @@ def test_request_matches_post_params():
 
     run()
     assert_reset()
+
+
+def test_request_matches_post_keys():
+    @responses.activate
+    def run():
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="one",
+            match=[responses.json_keys_matcher(["from", "to"])],
+        )
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="two",
+            match=[responses.urlencoded_keys_matcher(["from", "to"])],
+        )
+
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={"Content-Type": "x-www-form-urlencoded"},
+            data={"from": 12, "to": 24},
+        )
+        assert_response(resp, "two")
+
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={"Content-Type": "application/json"},
+            json={"from": 12, "to": 24},
+        )
+        assert_response(resp, "one")
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Closes #335 

I'm not really satisfied with the external API:
- `responses.assert_call_count(url, 2, match_querystring=False)` is a bit clunky
- `match_querystring` should maybe be `False` by default to match capture behaviour? But then the change is not backwards compatible :o

The internal change with `call_url_matches` is not really clean either, I don't know how to improve it :\