### PR TITLE
Add requirement for urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ install_requires = [
     "cookies; python_version < '3.4'",
     "mock; python_version < '3.3'",
     "requests>=2.0",
+    "urllib3>=1.25.10",
     "six",
 ]
 


### PR DESCRIPTION
This upgrades urllib3 to a version that provides the cookie interfaces that this library depends on. Earlier versions lack a get_all() method on HTTPHeaderDict

Refs #292