### PR TITLE
Allow matching on empty request body

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -236,7 +236,11 @@ _unspecified = object()
 
 def urlencoded_params_matcher(params):
     def match(request_body):
-        return sorted(params.items()) == sorted(parse_qsl(request_body))
+        return (
+            params is None
+            if request_body is None
+            else sorted(params.items()) == sorted(parse_qsl(request_body))
+        )
 
     return match
 

--- a/responses.py
+++ b/responses.py
@@ -246,7 +246,11 @@ def json_params_matcher(params):
         try:
             if isinstance(request_body, bytes):
                 request_body = request_body.decode("utf-8")
-            return params == json_module.loads(request_body)
+            return (
+                params is None
+                if request_body is None
+                else params == json_module.loads(request_body)
+            )
         except JSONDecodeError:
             return False
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -1240,8 +1240,22 @@ def test_request_matches_empty_body():
             match=[responses.json_params_matcher(None)],
         )
 
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="two",
+            match=[responses.urlencoded_params_matcher(None)],
+        )
+
         resp = requests.request("POST", "http://example.com/",)
         assert_response(resp, "one")
+
+        resp = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={"Content-Type": "x-www-form-urlencoded"},
+        )
+        assert_response(resp, "two")
 
     run()
     assert_reset()

--- a/test_responses.py
+++ b/test_responses.py
@@ -1228,3 +1228,20 @@ def test_request_matches_post_params():
 
     run()
     assert_reset()
+
+
+def test_request_matches_empty_body():
+    @responses.activate
+    def run():
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="one",
+            match=[responses.json_params_matcher(None)],
+        )
+
+        resp = requests.request("POST", "http://example.com/",)
+        assert_response(resp, "one")
+
+    run()
+    assert_reset()

--- a/test_responses.py
+++ b/test_responses.py
@@ -1247,7 +1247,7 @@ def test_request_matches_empty_body():
             match=[responses.urlencoded_params_matcher(None)],
         )
 
-        resp = requests.request("POST", "http://example.com/",)
+        resp = requests.request("POST", "http://example.com/")
         assert_response(resp, "one")
 
         resp = requests.request(


### PR DESCRIPTION
If there was no body sent in the original request it comes into the matcher as `None`.