### PR TITLE
Allow request.params to have multiple values for the same key

### DIFF
--- a/test_responses.py
+++ b/test_responses.py
@@ -1152,6 +1152,22 @@ def test_request_param(url):
     assert_reset()
 
 
+def test_request_param_with_multiple_values_for_the_same_key():
+    @responses.activate
+    def run():
+        url = "http://example.com"
+        params = {"key1": ["one", "two"], "key2": "three"}
+        responses.add(
+            method=responses.GET, url=url, body="test",
+        )
+        resp = requests.get(url, params=params)
+        assert_response(resp, "test")
+        assert resp.request.params == params
+
+    run()
+    assert_reset()
+
+
 @pytest.mark.parametrize(
     "url", ("http://example.com", "http://example.com?hello=world")
 )


### PR DESCRIPTION
After incorporating https://github.com/getsentry/responses/pull/301, responses can return requested parameters by `responses.calls[].request.params`, but it doesn't support multiple values for the same parameter for now.

Although there is no standard about the multiple values for the same request parameter, requests can accept list as value of `params` (ref. [Passing Parameters In URLs](https://requests.readthedocs.io/en/master/user/quickstart/#passing-parameters-in-urls)), so I feel it is better to handle it in the same way.
