### PR TITLE
Change match_failed_reasons extract in _on_request to prevent crash.

### DIFF
--- a/responses.py
+++ b/responses.py
@@ -677,7 +677,12 @@ class RequestsMock(object):
         return params
 
     def _on_request(self, adapter, request, **kwargs):
-        match, match_failed_reasons = self._find_match(request)
+        match_failed_reasons = []
+        match = self._find_match(request)
+        # Some libraries mock `_find_match` and return single result,
+        # So, we extract `match_failed_reasons` like this to prevent crash
+        if isinstance(match, tuple) and len(match) == 2:
+            match, match_failed_reasons = match
         resp_callback = self.response_callback
         request.params = self._parse_request_params(request.path_url)
 

--- a/test_responses.py
+++ b/test_responses.py
@@ -1299,3 +1299,20 @@ def test_fail_request_error():
 
     run()
     assert_reset()
+
+
+def test_mock_find_match():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add("POST", url)
+
+        with patch(
+            "responses.RequestsMock._find_match",
+            return_value=Response(method=responses.GET, url=url),
+        ):
+            response = requests.post("http://example.com/")
+        assert response.url == url
+
+    run()
+    assert_reset()


### PR DESCRIPTION
Fixes https://github.com/getsentry/responses/issues/358