### PR TITLE
Documentation: Fix an examples in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,9 +148,9 @@ other formats.
         responses.add(
             responses.POST,
             url='http://calc.com/sum',
-            body=4,
+            body="4",
             match=[
-                responses.urlencoded_params_matcher({"left": 1, "right": 3})
+                responses.urlencoded_params_matcher({"left": "1", "right": "3"})
             ]
         )
         requests.post("http://calc.com/sum", data={"left": 1, "right": 3})


### PR DESCRIPTION
Fix the `test_calc_api()` example in "Matching Request Parameters"
    
- `body` paramater of `responses.add()` does not accept arguments of type
  `int`. Changed to `str`.
- Values in the request parameters given to
  `responses.urlencoded_params_matcher()` must be of type `str`. Otherwise,
  `ConnectionError` is thrown, because of not matching parameters.