### PR TITLE
Add type stubs

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, print_function, division, unicode_literals
+from typing import List
 
 import _io
 import inspect
@@ -193,6 +194,10 @@ def get_wrapped(func, responses):
     wrapper = evaldict["wrapper"]
     update_wrapper(wrapper, func)
     return wrapper
+
+
+calls_2: List[Call] = []
+bar = iter(calls_2)
 
 
 class CallList(Sequence, Sized):

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, print_function, division, unicode_literals
-from typing import List
 
 import _io
 import inspect
@@ -194,10 +193,6 @@ def get_wrapped(func, responses):
     wrapper = evaldict["wrapper"]
     update_wrapper(wrapper, func)
     return wrapper
-
-
-calls_2: List[Call] = []
-bar = iter(calls_2)
 
 
 class CallList(Sequence, Sized):

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -1,0 +1,285 @@
+from collections import Sequence, Sized
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    Mapping,
+    Optional,
+    Pattern,
+    NamedTuple,
+    Protocol,
+    TypeVar,
+)
+from io import BufferedReader, BytesIO
+from re import Pattern
+from requests.adapters import HTTPResponse, PreparedRequest
+from requests.cookies import RequestsCookieJar
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing_extensions import Literal
+from unittest import mock as std_mock
+from urllib.parse import quote as quote
+from urllib3.response import HTTPHeaderDict
+
+JSONDecodeError = ValueError
+
+def _clean_unicode(url: str) -> str: ...
+def _cookies_from_headers(headers: Dict[str, str]) -> RequestsCookieJar: ...
+def _ensure_str(s: str) -> str: ...
+def _ensure_url_default_path(
+    url: Union[Pattern[str], str]
+) -> Union[Pattern[str], str]: ...
+def _handle_body(
+    body: Optional[Union[bytes, BufferedReader, str]]
+) -> Union[BufferedReader, BytesIO]: ...
+def _has_unicode(s: str) -> bool: ...
+def _is_string(s: Union[Pattern[str], str]) -> bool: ...
+def get_wrapped(
+    func: Callable[..., Any], responses: RequestsMock
+) -> Callable[..., Any]: ...
+def json_params_matcher(
+    params: Optional[Dict[str, Dict[str, str]]]
+) -> Callable[..., Any]: ...
+def urlencoded_params_matcher(
+    params: Optional[Dict[str, str]]
+) -> Callable[..., Any]: ...
+
+class Call(NamedTuple):
+    request: PreparedRequest
+    response: Any
+
+_Body = Union[str, BaseException, "Response", BufferedReader, bytes]
+
+class CallList(Sequence[Call], Sized):
+    def __init__(self) -> None: ...
+    def __iter__(self) -> Iterator[Call]: ...
+    def __len__(self) -> int: ...
+    def __getitem__(self, idx: int) -> Call: ...  # type: ignore [override]
+    def add(self, request: PreparedRequest, response: _Body) -> None: ...
+    def reset(self) -> None: ...
+
+class BaseResponse:
+    content_type: Optional[str] = ...
+    headers: Optional[Mapping[str, str]] = ...
+    stream: bool = ...
+    method: Any = ...
+    url: Any = ...
+    match_querystring: Any = ...
+    match: List[Any] = ...
+    call_count: int = ...
+    def __init__(
+        self,
+        method: str,
+        url: Union[Pattern[str], str],
+        match_querystring: Union[bool, object] = ...,
+        match: List[Callable[..., Any]] = ...,
+    ) -> None: ...
+    def __eq__(self, other: Any) -> bool: ...
+    def __ne__(self, other: Any) -> bool: ...
+    def _body_matches(
+        self, match: List[Callable[..., Any]], request_body: Optional[Union[bytes, str]]
+    ) -> bool: ...
+    def _should_match_querystring(
+        self, match_querystring_argument: Union[bool, object]
+    ) -> bool: ...
+    def _url_matches(
+        self, url: Union[Pattern[str], str], other: str, match_querystring: bool = ...
+    ) -> bool: ...
+    def _url_matches_strict(self, url: str, other: str) -> bool: ...
+    def get_headers(self) -> HTTPHeaderDict: ...  # type: ignore [no-any-unimported]
+    def get_response(self, request: PreparedRequest) -> None: ...
+    def matches(self, request: PreparedRequest) -> Tuple[bool, str]: ...
+
+class Response(BaseResponse):
+    body: _Body = ...
+    status: int = ...
+    headers: Optional[Mapping[str, str]] = ...
+    stream: bool = ...
+    content_type: Optional[str] = ...
+    def __init__(
+        self,
+        method: str,
+        url: Union[Pattern[str], str],
+        body: _Body = ...,
+        json: Optional[Any] = ...,
+        status: int = ...,
+        headers: Optional[Mapping[str, str]] = ...,
+        stream: bool = ...,
+        content_type: Optional[str] = ...,
+        match_querystring: bool = ...,
+        match: List[Any] = ...,
+    ) -> None: ...
+    def get_response(  # type: ignore [override]
+        self, request: PreparedRequest
+    ) -> HTTPResponse: ...
+
+class CallbackResponse(BaseResponse):
+    callback: Callable[[Any], Any] = ...
+    stream: bool = ...
+    content_type: Optional[str] = ...
+    def __init__(
+        self,
+        method: str,
+        url: Union[Pattern[str], str],
+        callback: Callable[[Any], Any],
+        stream: bool = ...,
+        content_type: Optional[str] = ...,
+        match_querystring: bool = ...,
+        match: List[Any] = ...,
+    ) -> None: ...
+    def get_response(  # type: ignore [override]
+        self, request: PreparedRequest
+    ) -> HTTPResponse: ...
+
+class OriginalResponseShim:
+    msg: Any = ...
+    def __init__(  # type: ignore [no-any-unimported]
+        self, headers: HTTPHeaderDict
+    ) -> None: ...
+    def isclosed(self) -> bool: ...
+
+class RequestsMock:
+    DELETE: Literal["DELETE"]
+    GET: Literal["GET"]
+    HEAD: Literal["HEAD"]
+    OPTIONS: Literal["OPTIONS"]
+    PATCH: Literal["PATCH"]
+    POST: Literal["POST"]
+    PUT: Literal["PUT"]
+    response_callback: Optional[Callable[[Any], Any]] = ...
+    assert_all_requests_are_fired: Any = ...
+    passthru_prefixes: Tuple[str, ...] = ...
+    target: Any = ...
+    _matches: List[Any]
+    def __init__(
+        self,
+        assert_all_requests_are_fired: bool = ...,
+        response_callback: Optional[Callable[[Any], Any]] = ...,
+        passthru_prefixes: Tuple[str, ...] = ...,
+        target: str = ...,
+    ) -> None: ...
+    def reset(self) -> None: ...
+    add: _Add
+    def add_passthru(self, prefix: str) -> None: ...
+    def remove(
+        self,
+        method_or_response: Optional[Union[str, Response]] = ...,
+        url: Optional[Union[Pattern[str], str]] = ...,
+    ) -> None: ...
+    replace: _Replace
+    add_callback: _AddCallback
+    @property
+    def calls(self) -> CallList: ...
+    def __enter__(self) -> RequestsMock: ...
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> bool: ...
+    activate: _Activate
+    def start(self) -> None: ...
+    def stop(self, allow_assert: bool = ...) -> None: ...
+    def assert_call_count(self, url: str, count: int) -> bool: ...
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+class _Activate(Protocol):
+    def __call__(self, func: _F) -> _F: ...
+
+class _Add(Protocol):
+    def __call__(
+        self,
+        method: Optional[str] = ...,
+        url: Optional[Union[Pattern[str], str]] = ...,
+        body: _Body = ...,
+        json: Optional[Any] = ...,
+        status: int = ...,
+        headers: Optional[Mapping[str, str]] = ...,
+        stream: bool = ...,
+        content_type: Optional[str] = ...,
+        adding_headers: Optional[Mapping[str, str]] = ...,
+        match_querystring: bool = ...,
+        match: List[Any] = ...,
+    ) -> None: ...
+
+class _AddCallback(Protocol):
+    def __call__(
+        self,
+        method: str,
+        url: Union[Pattern[str], str],
+        callback: Callable[..., str],
+        match_querystring: bool = ...,
+        content_type: Optional[str] = ...,
+    ) -> None: ...
+
+class _Remove(Protocol):
+    def __call__(
+        self,
+        method_or_response: Optional[Union[str, Response]] = ...,
+        url: Optional[Union[Pattern[str], str]] = ...,
+    ) -> None: ...
+
+class _Replace(Protocol):
+    def __call__(
+        self,
+        method_or_response: Optional[Union[str, Response]] = ...,
+        url: Optional[Union[Pattern[str], str]] = ...,
+        body: _Body = ...,
+        json: Optional[Any] = ...,
+        status: int = ...,
+        headers: Optional[Mapping[str, str]] = ...,
+        stream: bool = ...,
+        content_type: Optional[str] = ...,
+        adding_headers: Optional[Mapping[str, str]] = ...,
+        match_querystring: bool = ...,
+        match: List[Any] = ...,
+    ) -> None: ...
+
+activate: _Activate
+add: _Add
+add_callback: _AddCallback
+add_passthru: Callable[[str], None]
+assert_all_requests_are_fired: bool
+assert_call_count: Callable[[str, int], bool]
+calls: CallList
+DELETE: Literal["DELETE"]
+GET: Literal["GET"]
+HEAD: Literal["HEAD"]
+mock: RequestsMock
+_default_mock: RequestsMock
+OPTIONS: Literal["OPTIONS"]
+passthru_prefixes: Tuple[str, ...]
+PATCH: Literal["PATCH"]
+POST: Literal["POST"]
+PUT: Literal["PUT"]
+remove: _Remove
+replace: _Replace
+reset: Callable[[], None]
+response_callback: Callable[[Any], Any]
+start: Callable[[], None]
+stop: Callable[..., None]
+target: Any
+
+__all__ = [
+    "CallbackResponse",
+    "Response",
+    "RequestsMock",
+    # Exposed by the RequestsMock class:
+    "activate",
+    "add",
+    "add_callback",
+    "add_passthru",
+    "assert_all_requests_are_fired",
+    "assert_call_count",
+    "calls",
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "passthru_prefixes",
+    "PATCH",
+    "POST",
+    "PUT",
+    "remove",
+    "replace",
+    "reset",
+    "response_callback",
+    "start",
+    "stop",
+    "target",
+]

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -444,7 +444,11 @@ def test_callback():
     body = b"test callback"
     status = 400
     reason = "Bad Request"
-    headers = {"foo": "bar", "Content-Type": "application/json", "Content-Length": "13"}
+    headers = {
+        "foo": "bar",
+        "Content-Type": "application/json",
+        "Content-Length": "13",
+    }
     url = "http://example.com/"
 
     def request_callback(request):
@@ -531,7 +535,11 @@ def test_callback_no_content_type():
 
 def test_callback_content_type_dict():
     def request_callback(request):
-        return (200, {"Content-Type": "application/json"}, b"foo")
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            b"foo",
+        )
 
     @responses.activate
     def run():
@@ -546,7 +554,11 @@ def test_callback_content_type_dict():
 
 def test_callback_content_type_tuple():
     def request_callback(request):
-        return (200, [("Content-Type", "application/json")], b"foo")
+        return (
+            200,
+            [("Content-Type", "application/json")],
+            b"foo",
+        )
 
     @responses.activate
     def run():
@@ -1038,46 +1050,46 @@ def test_multiple_methods():
     assert_reset()
 
 
-# def test_passthru(httpserver):
-#     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
+def test_passthru(httpserver):
+    httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
-#     @responses.activate
-#     def run():
-#         responses.add_passthru(httpserver.url)
-#         responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
-#         responses.add(responses.GET, "http://example.com/two", body="two")
+    @responses.activate
+    def run():
+        responses.add_passthru(httpserver.url)
+        responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
+        responses.add(responses.GET, "http://example.com/two", body="two")
 
-#         resp = requests.get("http://example.com/two")
-#         assert_response(resp, "two")
-#         resp = requests.get("{}/one".format(httpserver.url))
-#         assert_response(resp, "one")
-#         resp = requests.get(httpserver.url)
-#         assert_response(resp, "OK")
+        resp = requests.get("http://example.com/two")
+        assert_response(resp, "two")
+        resp = requests.get("{}/one".format(httpserver.url))
+        assert_response(resp, "one")
+        resp = requests.get(httpserver.url)
+        assert_response(resp, "OK")
 
-#     run()
-#     assert_reset()
+    run()
+    assert_reset()
 
 
-# def test_passthru_regex(httpserver):
-#     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
+def test_passthru_regex(httpserver):
+    httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
-#     @responses.activate
-#     def run():
-#         responses.add_passthru(re.compile("{}/\\w+".format(httpserver.url)))
-#         responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
-#         responses.add(responses.GET, "http://example.com/two", body="two")
+    @responses.activate
+    def run():
+        responses.add_passthru(re.compile("{}/\\w+".format(httpserver.url)))
+        responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
+        responses.add(responses.GET, "http://example.com/two", body="two")
 
-#         resp = requests.get("http://example.com/two")
-#         assert_response(resp, "two")
-#         resp = requests.get("{}/one".format(httpserver.url))
-#         assert_response(resp, "one")
-#         resp = requests.get("{}/two".format(httpserver.url))
-#         assert_response(resp, "OK")
-#         resp = requests.get("{}/three".format(httpserver.url))
-#         assert_response(resp, "OK")
+        resp = requests.get("http://example.com/two")
+        assert_response(resp, "two")
+        resp = requests.get("{}/one".format(httpserver.url))
+        assert_response(resp, "one")
+        resp = requests.get("{}/two".format(httpserver.url))
+        assert_response(resp, "OK")
+        resp = requests.get("{}/three".format(httpserver.url))
+        assert_response(resp, "OK")
 
-#     run()
-#     assert_reset()
+    run()
+    assert_reset()
 
 
 def test_method_named_param():
@@ -1164,7 +1176,11 @@ def test_request_param_with_multiple_values_for_the_same_key():
     def run():
         url = "http://example.com"
         params = {"key1": ["one", "two"], "key2": "three"}
-        responses.add(method=responses.GET, url=url, body="test")
+        responses.add(
+            method=responses.GET,
+            url=url,
+            body="test",
+        )
         resp = requests.get(url, params=params)
         assert_response(resp, "test")
         assert resp.request.params == params

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -444,11 +444,7 @@ def test_callback():
     body = b"test callback"
     status = 400
     reason = "Bad Request"
-    headers = {
-        "foo": "bar",
-        "Content-Type": "application/json",
-        "Content-Length": "13",
-    }
+    headers = {"foo": "bar", "Content-Type": "application/json", "Content-Length": "13"}
     url = "http://example.com/"
 
     def request_callback(request):
@@ -535,11 +531,7 @@ def test_callback_no_content_type():
 
 def test_callback_content_type_dict():
     def request_callback(request):
-        return (
-            200,
-            {"Content-Type": "application/json"},
-            b"foo",
-        )
+        return (200, {"Content-Type": "application/json"}, b"foo")
 
     @responses.activate
     def run():
@@ -554,11 +546,7 @@ def test_callback_content_type_dict():
 
 def test_callback_content_type_tuple():
     def request_callback(request):
-        return (
-            200,
-            [("Content-Type", "application/json")],
-            b"foo",
-        )
+        return (200, [("Content-Type", "application/json")], b"foo")
 
     @responses.activate
     def run():
@@ -1050,46 +1038,46 @@ def test_multiple_methods():
     assert_reset()
 
 
-def test_passthru(httpserver):
-    httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
+# def test_passthru(httpserver):
+#     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
-    @responses.activate
-    def run():
-        responses.add_passthru(httpserver.url)
-        responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
-        responses.add(responses.GET, "http://example.com/two", body="two")
+#     @responses.activate
+#     def run():
+#         responses.add_passthru(httpserver.url)
+#         responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
+#         responses.add(responses.GET, "http://example.com/two", body="two")
 
-        resp = requests.get("http://example.com/two")
-        assert_response(resp, "two")
-        resp = requests.get("{}/one".format(httpserver.url))
-        assert_response(resp, "one")
-        resp = requests.get(httpserver.url)
-        assert_response(resp, "OK")
+#         resp = requests.get("http://example.com/two")
+#         assert_response(resp, "two")
+#         resp = requests.get("{}/one".format(httpserver.url))
+#         assert_response(resp, "one")
+#         resp = requests.get(httpserver.url)
+#         assert_response(resp, "OK")
 
-    run()
-    assert_reset()
+#     run()
+#     assert_reset()
 
 
-def test_passthru_regex(httpserver):
-    httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
+# def test_passthru_regex(httpserver):
+#     httpserver.serve_content("OK", headers={"Content-Type": "text/plain"})
 
-    @responses.activate
-    def run():
-        responses.add_passthru(re.compile("{}/\\w+".format(httpserver.url)))
-        responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
-        responses.add(responses.GET, "http://example.com/two", body="two")
+#     @responses.activate
+#     def run():
+#         responses.add_passthru(re.compile("{}/\\w+".format(httpserver.url)))
+#         responses.add(responses.GET, "{}/one".format(httpserver.url), body="one")
+#         responses.add(responses.GET, "http://example.com/two", body="two")
 
-        resp = requests.get("http://example.com/two")
-        assert_response(resp, "two")
-        resp = requests.get("{}/one".format(httpserver.url))
-        assert_response(resp, "one")
-        resp = requests.get("{}/two".format(httpserver.url))
-        assert_response(resp, "OK")
-        resp = requests.get("{}/three".format(httpserver.url))
-        assert_response(resp, "OK")
+#         resp = requests.get("http://example.com/two")
+#         assert_response(resp, "two")
+#         resp = requests.get("{}/one".format(httpserver.url))
+#         assert_response(resp, "one")
+#         resp = requests.get("{}/two".format(httpserver.url))
+#         assert_response(resp, "OK")
+#         resp = requests.get("{}/three".format(httpserver.url))
+#         assert_response(resp, "OK")
 
-    run()
-    assert_reset()
+#     run()
+#     assert_reset()
 
 
 def test_method_named_param():
@@ -1176,11 +1164,7 @@ def test_request_param_with_multiple_values_for_the_same_key():
     def run():
         url = "http://example.com"
         params = {"key1": ["one", "two"], "key2": "three"}
-        responses.add(
-            method=responses.GET,
-            url=url,
-            body="test",
-        )
+        responses.add(method=responses.GET, url=url, body="test")
         resp = requests.get(url, params=params)
         assert_response(resp, "test")
         assert resp.request.params == params

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     tests_require=tests_require,
     setup_requires=setup_requires,
     cmdclass={"test": PyTest},
-    package_data={'responses': ['py.typed']},
+    package_data={"responses": ["py.typed"]},
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     license="Apache 2.0",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    py_modules=["responses"],
+    packages=["responses"],
     zip_safe=False,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=install_requires,
@@ -70,6 +70,7 @@ setup(
     tests_require=tests_require,
     setup_requires=setup_requires,
     cmdclass={"test": PyTest},
+    package_data={'responses': ['py.typed']},
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
Add type stubs for the library as a separate stub file which means we can
use the python 3 syntax, with the downside of having to keep them in
sync with the source.

I ran [monkeytype][1] and [stubgen][2] over responses.py and combined the
results manually.

I had to move the module into a package for the types to work.
see: https://www.python.org/dev/peps/pep-0561/#packaging-type-information

Fixes #339

https://www.python.org/dev/peps/pep-0561/

[1]: https://github.com/Instagram/MonkeyType
[2]: https://mypy.readthedocs.io/en/stable/stubgen.html