### PR TITLE
Fix erroneous typing for callback function

### DIFF
--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -203,7 +203,7 @@ class _AddCallback(Protocol):
         self,
         method: str,
         url: Union[Pattern[str], str],
-        callback: Callable[..., str],
+        callback: Callable[[PreparedRequest], Union[Exception, Tuple[int, Mapping[str, str], _Body]]],
         match_querystring: bool = ...,
         content_type: Optional[str] = ...,
     ) -> None: ...


### PR DESCRIPTION
Since the type stub is not covered by the automated tests, I decided to change as little as possible. The new type hints for the callback should match with [how the callback is invoked and used](https://github.com/getsentry/responses/blob/master/responses/__init__.py#L445), though I have only tested it on a project I'm working on that makes use of the responses library.

EDIT: This should fix #379