### PR TITLE
Fix version bumper to work with double quotes

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -16,4 +16,4 @@ function replace() {
     grep "$2" "$3"  # verify that replacement was successful
 }
 
-replace "version='[^']*'" "version='$NEW_VERSION'" ./setup.py
+replace "version=\"[^\"]*\"" "version=\"$NEW_VERSION\"" ./setup.py


### PR DESCRIPTION
Follow-up from #383. Tested locally:

```
$ bash scripts/bump-version.sh 0.13.2 CHEESE
++ dirname scripts/bump-version.sh
+ cd scripts/..
+ OLD_VERSION=0.13.2
+ NEW_VERSION=CHEESE
+ echo 'Current version: 0.13.2'
Current version: 0.13.2
+ echo 'Bumping version: CHEESE'
Bumping version: CHEESE
+ replace 'version="[^"]*"' 'version="CHEESE"' ./setup.py
+ grep 'version="CHEESE"' ./setup.py
+ sed -e 's/version="[^"]*"/version="CHEESE"/g' ./setup.py
+ mv ./setup.py.tmp ./setup.py
+ grep 'version="CHEESE"' ./setup.py
    version="CHEESE",
$ gd
```

```diff
diff --git a/setup.py b/setup.py
index 92c4c85..38d96df 100644
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class PyTest(TestCommand):
 
 setup(
     name="responses",
-    version="0.13.2",
+    version="CHEESE",
     author="David Cramer",
     description=("A utility library for mocking out the `requests` Python library."),
     url="https://github.com/getsentry/responses",
```