### PR TITLE
rfc compliant url logic

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -330,18 +330,14 @@ class BaseResponse(object):
 
             if match_querystring:
                 rfc_compliant_url = parse_url(url).url
-                rfc_result = self._url_matches_strict(rfc_compliant_url, other)
-                non_rfc_result = self._url_matches_strict(url, other)
-                return non_rfc_result or rfc_result
+                return self._url_matches_strict(rfc_compliant_url, other)
 
             else:
                 url_without_qs = url.split("?", 1)[0]
                 other_without_qs = other.split("?", 1)[0]
                 rfc_compliant_url_without_qs = parse_url(url_without_qs).url
 
-                rfc_result = rfc_compliant_url_without_qs == other_without_qs
-                non_rfc_result = url_without_qs == other_without_qs
-                return non_rfc_result or rfc_result
+                return rfc_compliant_url_without_qs == other_without_qs
 
         elif isinstance(url, Pattern) and url.match(other):
             return True

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -1472,3 +1472,23 @@ def test_mocked_responses_list_registered():
 
     run()
     assert_reset()
+
+
+@pytest.mark.parametrize(
+    "url,other_url",
+    [
+        ("http://service-A/foo?q=fizz", "http://service-a/foo?q=fizz"),
+        ("http://service-a/foo", "http://service-A/foo"),
+        ("http://someHost-AwAy/", "http://somehost-away/"),
+        ("http://fizzbuzz/foo", "http://fizzbuzz/foo"),
+    ],
+)
+def test_rfc_compliance(url, other_url):
+    @responses.activate
+    def run():
+        responses.add(method=responses.GET, url=url)
+        resp = requests.request("GET", other_url)
+        assert_response(resp, "")
+
+    run()
+    assert_reset()


### PR DESCRIPTION
This addresses the fact that currently URLs are not matched using [RFCC-3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2) compliant host-names. When adding a mock URL such as `http://some-URL-HERE`, then we should expect that both `http://some-URL-HERE` and `http://some-url-here` should pass when submitting requests. Per the RFC:
> The host sub-component is case-insensitive.