### PR TITLE
Add flag to allow automatic calculation of the Content-Length header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,9 @@ headers (``dict``)
 stream (``bool``)
     Disabled by default. Indicates the response should use the streaming API.
 
+auto_calculate_content_length (``bool``)
+    Disabled by default. Automatically calculates the length of a supplied string or JSON body.
+
 match (``list``)
     A list of callbacks to match requests based on request body contents.
 

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -95,6 +95,7 @@ class Response(BaseResponse):
     headers: Optional[Mapping[str, str]] = ...
     stream: bool = ...
     content_type: Optional[str] = ...
+    auto_calculate_content_length: bool = ...
     def __init__(
         self,
         method: str,
@@ -105,6 +106,7 @@ class Response(BaseResponse):
         headers: Optional[Mapping[str, str]] = ...,
         stream: bool = ...,
         content_type: Optional[str] = ...,
+        auto_calculate_content_length: bool = ...,
         match_querystring: bool = ...,
         match: List[Any] = ...,
     ) -> None: ...
@@ -193,6 +195,7 @@ class _Add(Protocol):
         headers: Optional[Mapping[str, str]] = ...,
         stream: bool = ...,
         content_type: Optional[str] = ...,
+        auto_calculate_content_length: bool = ...,
         adding_headers: Optional[Mapping[str, str]] = ...,
         match_querystring: bool = ...,
         match: List[Any] = ...,

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -1081,6 +1081,114 @@ def test_legacy_adding_headers():
     assert_reset()
 
 
+def test_auto_calculate_content_length_string_body():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            responses.GET, url, body="test", auto_calculate_content_length=True
+        )
+        resp = requests.get(url)
+        assert_response(resp, "test")
+        assert resp.headers["Content-Length"] == "4"
+
+    run()
+    assert_reset()
+
+
+def test_auto_calculate_content_length_bytes_body():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            responses.GET, url, body=b"test bytes", auto_calculate_content_length=True
+        )
+        resp = requests.get(url)
+        assert_response(resp, "test bytes")
+        assert resp.headers["Content-Length"] == "10"
+
+    run()
+    assert_reset()
+
+
+def test_auto_calculate_content_length_json_body():
+    @responses.activate
+    def run():
+        content_type = "application/json"
+
+        url = "http://example.com/"
+        responses.add(
+            responses.GET,
+            url,
+            json={"message": "success"},
+            auto_calculate_content_length=True,
+        )
+        resp = requests.get(url)
+        assert_response(resp, '{"message": "success"}', content_type)
+        assert resp.headers["Content-Length"] == "22"
+
+        url = "http://example.com/1/"
+        responses.add(responses.GET, url, json=[], auto_calculate_content_length=True)
+        resp = requests.get(url)
+        assert_response(resp, "[]", content_type)
+        assert resp.headers["Content-Length"] == "2"
+
+    run()
+    assert_reset()
+
+
+def test_auto_calculate_content_length_unicode_body():
+    @responses.activate
+    def run():
+        url = "http://example.com/test"
+        responses.add(
+            responses.GET, url, body="михољско лето", auto_calculate_content_length=True
+        )
+        resp = requests.get(url)
+        assert_response(resp, "михољско лето", content_type="text/plain; charset=utf-8")
+        assert resp.headers["Content-Length"] == "25"
+
+    run()
+    assert_reset()
+
+
+def test_auto_calculate_content_length_doesnt_work_for_buffered_reader_body():
+    @responses.activate
+    def run():
+        url = "http://example.com/test"
+        responses.add(
+            responses.GET,
+            url,
+            body=BufferedReader(BytesIO(b"testing")),  # type: ignore
+            auto_calculate_content_length=True,
+        )
+        resp = requests.get(url)
+        assert_response(resp, "testing")
+        assert "Content-Length" not in resp.headers
+
+    run()
+    assert_reset()
+
+
+def test_auto_calculate_content_length_doesnt_override_existing_value():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            responses.GET,
+            url,
+            body="test",
+            headers={"Content-Length": "2"},
+            auto_calculate_content_length=True,
+        )
+        resp = requests.get(url)
+        assert_response(resp, "test")
+        assert resp.headers["Content-Length"] == "2"
+
+    run()
+    assert_reset()
+
+
 def test_multiple_responses():
     @responses.activate
     def run():


### PR DESCRIPTION
To be correct, the Content-Length header must be calculated from the
binary representation of the body. This is calculated as late as
possible by calling _handle_body(), and this is all done privately
within the module. Therefore, it's easiest if this is done in a
centralised place as late as possible by this module.

Every attempt I made at implementing this by extended the relevant
code just resulted in oodles of unnecessarily duplicated code compared
to what is possible by just integrating it directly.

I know this was previously tackled six years ago in #70. In that PR,
the concern was that the header was being added unconditionally. I
have mitigated this problem in my PR by controlling the new behaviour
with a flag. There are still plenty of situations where you wouldn't
want the Content-Length header to be set, so this new behaviour is
fully backwards-compatible.