### PR TITLE
refactor find matches algorithm

### DIFF
--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -137,6 +137,29 @@ def test_replace(original, replacement):
     assert_reset()
 
 
+def test_replace_order():
+    @responses.activate
+    def run():
+        responses.add(responses.GET, "http://example.com", body="1")
+        responses.add(responses.GET, "http://example.com", body="2")
+
+        resp = requests.get("http://example.com")
+        assert_response(resp, "1")
+        resp = requests.get("http://example.com")
+        assert_response(resp, "2")
+
+        responses.replace(responses.GET, "http://example.com", body="3")
+        resp = requests.get("http://example.com")
+        assert_response(resp, "3")
+
+        # check that it remains the fallback response.
+        resp = requests.get("http://example.com")
+        assert_response(resp, "3")
+
+    run()
+    assert_reset()
+
+
 @pytest.mark.parametrize(
     "original,replacement",
     [
@@ -891,7 +914,7 @@ def test_response_callback():
 
 @pytest.mark.skipif(six.PY2, reason="re.compile works differntly in PY2")
 def test_response_filebody():
-    """ Adds the possibility to use actual (binary) files as responses """
+    """Adds the possibility to use actual (binary) files as responses"""
 
     def run():
         current_file = os.path.abspath(__file__)


### PR DESCRIPTION
This PR changes the algorithm to find matches. It implements the following algorithm:

Loop in normal order and provide responses with `call_count == 0`. If there is no match found, loop in reverse order and provide all responses with `call_count > 0`.

This will behave like before for most use cases. There could only be cases that failed before which would now pass, e.g. imagine the following situation:
`registry: [r'.*', 'abc']`.
In previous implementation a call with
`requests: ['abc', 'abc', 'xyz']` would have failed, because the first `abc` would have popped the "match everything" response. In this implementation, it would still work.

In my opinion this algorithm is easier to explain and comprehend and should be backward compatible with all previous use cases. Except those relying on a failure due to a popped response, which would be a very special edge case which I would not expect by any user at all.