### PR TITLE
mbeliaev/stream

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
   to match additional request arguments like `stream`.
 * Changed all matchers output message in case of mismatch. Now message is aligned
   between Python2 and Python3 versions
+* Deprecate ``stream`` argument in ``Response`` and ``CallbackResponse``
 
 0.14.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ headers (``dict``)
     Response headers.
 
 stream (``bool``)
-    Disabled by default. Indicates the response should use the streaming API.
+    DEPRECATED
 
 auto_calculate_content_length (``bool``)
     Disabled by default. Automatically calculates the length of a supplied string or JSON body.

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -361,7 +361,7 @@ class Response(BaseResponse):
         json=None,
         status=200,
         headers=None,
-        stream=False,
+        stream=None,
         content_type=UNSET,
         auto_calculate_content_length=False,
         **kwargs
@@ -383,6 +383,12 @@ class Response(BaseResponse):
         self.body = body
         self.status = status
         self.headers = headers
+
+        if stream is not None:
+            warn(
+                "stream argument is deprecated. Use stream parameter in request directly"
+            )
+
         self.stream = stream
         self.content_type = content_type
         self.auto_calculate_content_length = auto_calculate_content_length
@@ -427,9 +433,14 @@ class Response(BaseResponse):
 
 class CallbackResponse(BaseResponse):
     def __init__(
-        self, method, url, callback, stream=False, content_type="text/plain", **kwargs
+        self, method, url, callback, stream=None, content_type="text/plain", **kwargs
     ):
         self.callback = callback
+
+        if stream is not None:
+            warn(
+                "stream argument is deprecated. Use stream parameter in request directly"
+            )
         self.stream = stream
         self.content_type = content_type
         super(CallbackResponse, self).__init__(method, url, **kwargs)
@@ -767,12 +778,10 @@ class RequestsMock(object):
                 response = resp_callback(response) if resp_callback else response
                 raise
 
-        if not match.stream:
+        stream = kwargs.get("stream") if match.stream is None else match.stream
+        if not stream:
             content = response.content
-            if kwargs.get("stream"):
-                response.raw = BufferIO(content)
-            else:
-                response.close()
+            response.raw = BufferIO(content)
 
         response = resp_callback(response) if resp_callback else response
         match.call_count += 1


### PR DESCRIPTION
@markstory 
I went through the code of `urllib3` and `requests`. I cannot find a good reason why we need `stream` argument in `Response` object. If you send a normal request, then `stream` is controlled by `request` itself.
There are multiple PRs and issues regarding the stream, it is very confusing

current PR keeps backwards compatibility for now, but deprecates `Response`'s `stream` argument in favor of `stream` argument from `request` kwargs

please point me to some use case if I missed some, then we probably need to add some additional tests to cover it

@carloshorn 
I see that you also worked on this part. I modified it a bit and test that you created passes just fine.
would you be also able to check the proposed change and see if that has some implications on `passthrough` workflow ?