### PR TITLE
Fix regression from stream deprecation

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -783,7 +783,10 @@ class RequestsMock(object):
         stream = kwargs.get("stream") if match.stream is None else match.stream
         if not stream:
             content = response.content
-            response.raw = BufferIO(content)
+            if kwargs.get("stream"):
+                response.raw = BufferIO(content)
+            else:
+                response.close()
 
         response = resp_callback(response) if resp_callback else response
         match.call_count += 1

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -780,14 +780,6 @@ class RequestsMock(object):
                 response = resp_callback(response) if resp_callback else response
                 raise
 
-        stream = kwargs.get("stream") if match.stream is None else match.stream
-        if not stream:
-            content = response.content
-            if kwargs.get("stream"):
-                response.raw = BufferIO(content)
-            else:
-                response.close()
-
         response = resp_callback(response) if resp_callback else response
         match.call_count += 1
         self._calls.add(request, response)

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -182,6 +182,8 @@ class RequestsMock:
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
+HeaderSet = Optional[Union[Mapping[str, str], List[Tuple[str, str]]]]
+
 class _Activate(Protocol):
     def __call__(self, func: _F) -> _F: ...
 
@@ -193,11 +195,11 @@ class _Add(Protocol):
         body: _Body = ...,
         json: Optional[Any] = ...,
         status: int = ...,
-        headers: Optional[Mapping[str, str]] = ...,
+        headers: HeaderSet = ...,
         stream: bool = ...,
         content_type: Optional[str] = ...,
         auto_calculate_content_length: bool = ...,
-        adding_headers: Optional[Mapping[str, str]] = ...,
+        adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: List[Any] = ...,
     ) -> None: ...
@@ -232,10 +234,10 @@ class _Replace(Protocol):
         body: _Body = ...,
         json: Optional[Any] = ...,
         status: int = ...,
-        headers: Optional[Mapping[str, str]] = ...,
+        headers: HeaderSet = ...,
         stream: bool = ...,
         content_type: Optional[str] = ...,
-        adding_headers: Optional[Mapping[str, str]] = ...,
+        adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: List[Any] = ...,
     ) -> None: ...
@@ -248,10 +250,10 @@ class _Upsert(Protocol):
         body: _Body = ...,
         json: Optional[Any] = ...,
         status: int = ...,
-        headers: Optional[Mapping[str, str]] = ...,
+        headers: HeaderSet = ...,
         stream: bool = ...,
         content_type: Optional[str] = ...,
-        adding_headers: Optional[Mapping[str, str]] = ...,
+        adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: List[Any] = ...,
     ) -> None: ...

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -935,6 +935,37 @@ def test_response_cookies_session():
     assert_reset()
 
 
+def test_response_cookies_session_stream():
+    @responses.activate
+    def run():
+        url = "https://example.com/path"
+        with pytest.deprecated_call():
+            responses.add(
+                responses.GET,
+                url,
+                headers=[
+                    ("Set-cookie", "mycookie=cookieval; path=/; secure"),
+                ],
+                body="ok",
+                stream=False, # Deprecated
+            )
+        session = requests.session()
+        resp = session.get(url, stream=True)
+        assert resp.text == "ok"
+        assert resp.status_code == 200
+
+        assert "mycookie" in resp.cookies
+        assert resp.cookies["mycookie"] == "cookieval"
+        assert set(resp.cookies.keys()) == set(["mycookie"])
+
+        assert "mycookie" in session.cookies
+        assert session.cookies["mycookie"] == "cookieval"
+        assert set(session.cookies.keys()) == set(["mycookie"])
+
+    run()
+    assert_reset()
+
+
 def test_response_callback():
     """adds a callback to decorate the response, then checks it"""
 

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -944,37 +944,6 @@ def test_response_cookies_session(responses_stream, request_stream):
     assert_reset()
 
 
-def test_response_cookies_session_stream():
-    @responses.activate
-    def run():
-        url = "https://example.com/path"
-        with pytest.deprecated_call():
-            responses.add(
-                responses.GET,
-                url,
-                headers=[
-                    ("Set-cookie", "mycookie=cookieval; path=/; secure"),
-                ],
-                body="ok",
-                stream=False,  # Deprecated
-            )
-        session = requests.session()
-        resp = session.get(url, stream=True)
-        assert resp.text == "ok"
-        assert resp.status_code == 200
-
-        assert "mycookie" in resp.cookies
-        assert resp.cookies["mycookie"] == "cookieval"
-        assert set(resp.cookies.keys()) == set(["mycookie"])
-
-        assert "mycookie" in session.cookies
-        assert session.cookies["mycookie"] == "cookieval"
-        assert set(session.cookies.keys()) == set(["mycookie"])
-
-    run()
-    assert_reset()
-
-
 def test_response_callback():
     """adds a callback to decorate the response, then checks it"""
 

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -911,7 +911,7 @@ def test_response_cookies_multiple():
     (True, False, None),
 )
 @pytest.mark.parametrize(
-    "responses_stream",
+    "responses_stream",  # The Response stream parameter is deprecated
     (True, False, None),
 )
 def test_response_cookies_session(responses_stream, request_stream):

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -857,7 +857,7 @@ def test_response_cookies():
     assert_reset()
 
 
-def test_response_secure_cookies():
+def test_response_cookies_secure():
     body = b"test callback"
     status = 200
     headers = {"set-cookie": "session_id=12345; a=b; c=d; secure"}
@@ -901,6 +901,35 @@ def test_response_cookies_multiple():
         assert set(resp.cookies.keys()) == set(["1P_JAR", "NID"])
         assert resp.cookies["1P_JAR"] == "2019-12-31-23"
         assert resp.cookies["NID"] == "some=value"
+
+    run()
+    assert_reset()
+
+
+def test_response_cookies_session():
+    @responses.activate
+    def run():
+        url = "https://example.com/path"
+        responses.add(
+            responses.GET,
+            url,
+            headers=[
+                ("Set-cookie", "mycookie=cookieval; path=/; secure"),
+            ],
+            body="ok",
+        )
+        session = requests.session()
+        resp = session.get(url)
+        assert resp.text == "ok"
+        assert resp.status_code == 200
+
+        assert "mycookie" in resp.cookies
+        assert resp.cookies["mycookie"] == "cookieval"
+        assert set(resp.cookies.keys()) == set(["mycookie"])
+
+        assert "mycookie" in session.cookies
+        assert session.cookies["mycookie"] == "cookieval"
+        assert set(session.cookies.keys()) == set(["mycookie"])
 
     run()
     assert_reset()

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -906,7 +906,15 @@ def test_response_cookies_multiple():
     assert_reset()
 
 
-def test_response_cookies_session():
+@pytest.mark.parametrize(
+    "request_stream",
+    (True, False, None),
+)
+@pytest.mark.parametrize(
+    "responses_stream",
+    (True, False, None),
+)
+def test_response_cookies_session(responses_stream, request_stream):
     @responses.activate
     def run():
         url = "https://example.com/path"
@@ -917,9 +925,10 @@ def test_response_cookies_session():
                 ("Set-cookie", "mycookie=cookieval; path=/; secure"),
             ],
             body="ok",
+            stream=responses_stream,
         )
         session = requests.session()
-        resp = session.get(url)
+        resp = session.get(url, stream=request_stream)
         assert resp.text == "ok"
         assert resp.status_code == 200
 
@@ -947,7 +956,7 @@ def test_response_cookies_session_stream():
                     ("Set-cookie", "mycookie=cookieval; path=/; secure"),
                 ],
                 body="ok",
-                stream=False, # Deprecated
+                stream=False,  # Deprecated
             )
         session = requests.session()
         resp = session.get(url, stream=True)


### PR DESCRIPTION
The stream handling seems to break things; and it appears that the response is already in the correct state anyway.

Fixes #421 