### PR TITLE
Mbeliaev/clean tests

### DIFF
--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -802,7 +802,7 @@ def test_activate_mock_interaction():
 @pytest.mark.skipif(six.PY2, reason="Cannot run in python2")
 def test_activate_doesnt_change_signature_with_return_type():
     def test_function(a, b=None):
-        return (a, b)
+        return a, b
 
     # Add type annotations as they are syntax errors in py2.
     # Use a class to test for import errors in evaled code.

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -810,14 +810,10 @@ def test_activate_doesnt_change_signature_with_return_type():
     test_function.__annotations__["a"] = Mock
 
     decorated_test_function = responses.activate(test_function)
-    if hasattr(inspect, "signature"):
-        assert inspect.signature(test_function) == inspect.signature(
-            decorated_test_function
-        )
-    else:
-        assert inspect.getargspec(test_function) == inspect.getargspec(
-            decorated_test_function
-        )
+    assert inspect.signature(test_function) == inspect.signature(
+        decorated_test_function
+    )
+
     assert decorated_test_function(1, 2) == test_function(1, 2)
     assert decorated_test_function(3) == test_function(3)
 


### PR DESCRIPTION
`inspect` has `signature` method starting from 3 but version 2 is marked as `skip` 

also, pushes tests coverage to 100% :)