### PR TITLE
remove travis badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ Responses
 .. image:: https://img.shields.io/pypi/v/responses.svg
     :target: https://pypi.python.org/pypi/responses/
 
-..  image:: https://travis-ci.org/getsentry/responses.svg?branch=master
-    :target: https://travis-ci.org/getsentry/responses
-
 .. image:: https://img.shields.io/pypi/pyversions/responses.svg
     :target: https://pypi.org/project/responses/
 


### PR DESCRIPTION
CI is moved to GH Actions, remove travis badge