### PR TITLE
update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Run Pytest
       run: |
         # Run test
-        pytest . --cov-report term-missing --cov .
+        pytest . --cov-report term-missing --cov responses
 
     - name: Code Coverage Report
       if: success()


### PR DESCRIPTION
run coverage on `responses` module only. Same as done in tox.ini

basically, this will exclude `setup.py` from coverage report