### PR TITLE
mbeliaev/query match

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@
 * Added `responses.matchers.fragment_identifier_matcher`. This matcher allows you
   to match request URL fragment identifier.
 * Improved test coverage.
+* Deprecate ``match_querystring`` argument in ``Response`` and ``CallbackResponse``.
+  Use `responses.matchers.query_param_matcher` or `responses.matchers.query_string_matcher`
 
 
 0.15.0

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,9 @@ url (``str`` or compiled regular expression)
     The full resource URL.
 
 match_querystring (``bool``)
+    DEPRECATED: Use `responses.matchers.query_param_matcher` or
+    `responses.matchers.query_string_matcher`
+
     Include the query string when matching requests.
     Enabled by default if the response URL contains a query string,
     disabled if it doesn't or the URL is a regular expression.

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -16,6 +16,7 @@ from requests.exceptions import ConnectionError
 from requests.utils import cookiejar_from_dict
 from responses.matchers import json_params_matcher as _json_params_matcher
 from responses.matchers import urlencoded_params_matcher as _urlencoded_params_matcher
+from responses.matchers import query_string_matcher as _query_string_matcher
 from warnings import warn
 
 try:
@@ -249,9 +250,6 @@ def _handle_body(body):
     return BufferIO(body)
 
 
-_unspecified = object()
-
-
 class BaseResponse(object):
     passthrough = False
     content_type = None
@@ -259,11 +257,14 @@ class BaseResponse(object):
 
     stream = False
 
-    def __init__(self, method, url, match_querystring=_unspecified, match=[]):
+    def __init__(self, method, url, match_querystring=None, match=[]):
         self.method = method
         # ensure the url has a default path set if the url is a string
         self.url = _ensure_url_default_path(url)
-        self.match_querystring = self._should_match_querystring(match_querystring)
+
+        if self._should_match_querystring(match_querystring):
+            match = tuple(match) + (_query_string_matcher(urlparse(self.url).query),)
+
         self.match = match
         self.call_count = 0
 
@@ -285,40 +286,32 @@ class BaseResponse(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def _url_matches_strict(self, url, other):
-        url_parsed = urlparse(url)
-        other_parsed = urlparse(other)
-
-        if url_parsed[:3] != other_parsed[:3]:
-            return False
-
-        url_qsl = sorted(parse_qsl(url_parsed.query))
-        other_qsl = sorted(parse_qsl(other_parsed.query))
-
-        return url_qsl == other_qsl
-
     def _should_match_querystring(self, match_querystring_argument):
-        if match_querystring_argument is not _unspecified:
-            return match_querystring_argument
-
         if isinstance(self.url, Pattern):
             # the old default from <= 0.9.0
             return False
 
+        if match_querystring_argument is not None:
+            warn(
+                (
+                    "Argument 'match_querystring' is deprecated. "
+                    "Use 'responses.matchers.query_param_matcher' or "
+                    "'responses.matchers.query_string_matcher'"
+                ),
+                DeprecationWarning,
+            )
+            return match_querystring_argument
+
         return bool(urlparse(self.url).query)
 
-    def _url_matches(self, url, other, match_querystring=False):
+    def _url_matches(self, url, other):
         if _is_string(url):
             if _has_unicode(url):
                 url = _clean_unicode(url)
                 if not isinstance(other, six.text_type):
                     other = other.encode("ascii").decode("utf8")
 
-            if match_querystring:
-                normalize_url = parse_url(url).url
-                return self._url_matches_strict(normalize_url, other)
-            else:
-                return _get_url_and_path(url) == _get_url_and_path(other)
+            return _get_url_and_path(url) == _get_url_and_path(other)
 
         elif isinstance(url, Pattern) and url.match(other):
             return True
@@ -350,7 +343,7 @@ class BaseResponse(object):
         if request.method != self.method:
             return False, "Method does not match"
 
-        if not self._url_matches(self.url, request.url, self.match_querystring):
+        if not self._url_matches(self.url, request.url):
             return False, "URL does not match"
 
         valid, reason = self._req_attr_matches(self.match, request)
@@ -579,14 +572,6 @@ class RequestsMock(object):
         >>>     headers={'X-Header': 'foo'},
         >>> )
 
-
-        Strict query string matching:
-
-        >>> responses.add(
-        >>>     method='GET',
-        >>>     url='http://example.com?foo=bar',
-        >>>     match_querystring=True
-        >>> )
         """
         if isinstance(method, BaseResponse):
             self._matches.append(method)

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -181,8 +181,8 @@ def query_string_matcher(query):
         data = parse_url(request.url)
         request_query = data.query
 
-        request_qsl = sorted(parse_qsl(request_query))
-        matcher_qsl = sorted(parse_qsl(query))
+        request_qsl = sorted(parse_qsl(request_query)) if request_query else {}
+        matcher_qsl = sorted(parse_qsl(query)) if query else {}
 
         valid = not query if request_query is None else request_qsl == matcher_qsl
 

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -175,7 +175,7 @@ def query_string_matcher(query):
     :param query: (str), same as constructed by request
     :return: (func) matcher
     """
-    if isinstance(query, unicode):  # noqa: F821
+    if six.PY2 and isinstance(query, unicode):  # noqa: F821
         query = query.encode("utf8")
 
     def match(request):

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -175,6 +175,8 @@ def query_string_matcher(query):
     :param query: (str), same as constructed by request
     :return: (func) matcher
     """
+    if isinstance(query, unicode):  # noqa: F821
+        query = query.encode("utf8")
 
     def match(request):
         reason = ""


### PR DESCRIPTION
Deprecate `match_querystring`

Current behavior  (_Include the query string when matching requests.
    Enabled by default if the response URL contains a query string,
    disabled if it doesn't or the URL is a regular expression._) might be not intuitive


* It is better to explicitly specify `matcher` with requested params.
* Change simplifies `Response` signature and lets `matchers` do its job and match URL
* This change also simplifies library code