### PR TITLE
handle ChunkedEncodingError

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -515,6 +515,9 @@ class OriginalResponseShim(object):
     def isclosed(self):
         return True
 
+    def close(self):
+        return
+
 
 class RequestsMock(object):
     DELETE = "DELETE"

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -1177,9 +1177,9 @@ def test_headers():
     assert_reset()
 
 
-def test_content_length_error():
+def test_content_length_error(monkeypatch):
     """
-    Currently 'requests' do not enforce content length validation,
+    Currently 'requests' does not enforce content length validation,
     (validation that body length matches header). However, this could
     be expected in next major version, see
     https://github.com/psf/requests/pull/3563
@@ -1203,15 +1203,15 @@ def test_content_length_error():
     original_init = getattr(requests.packages.urllib3.HTTPResponse, "__init__")
 
     def patched_init(self, *args, **kwargs):
-        original_init(self, *args, enforce_content_length=True, **kwargs)
+        kwargs["enforce_content_length"] = True
+        original_init(self, *args, **kwargs)
 
-    setattr(requests.packages.urllib3.HTTPResponse, "__init__", patched_init)
+    monkeypatch.setattr(
+        requests.packages.urllib3.HTTPResponse, "__init__", patched_init
+    )
 
-    try:
-        run()
-        assert_reset()
-    finally:
-        setattr(requests.packages.urllib3.HTTPResponse, "__init__", original_init)
+    run()
+    assert_reset()
 
 
 def test_legacy_adding_headers():

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -12,7 +12,7 @@ from sys import version_info
 import pytest
 import requests
 import responses
-from requests.exceptions import ConnectionError, HTTPError
+from requests.exceptions import ConnectionError, HTTPError, ChunkedEncodingError
 from responses import (
     BaseResponse,
     Response,
@@ -1175,6 +1175,43 @@ def test_headers():
 
     run()
     assert_reset()
+
+
+def test_content_length_error():
+    """
+    Currently 'requests' do not enforce content length validation,
+    (validation that body length matches header). However, this could
+    be expected in next major version, see
+    https://github.com/psf/requests/pull/3563
+
+    Now user can manually patch URL3 lib to achieve the same
+    """
+
+    @responses.activate
+    def run():
+        responses.add(
+            responses.GET,
+            "http://example.com/api/123",
+            json={"message": "this body is too large"},
+            adding_headers={"content-length": "2"},
+        )
+        with pytest.raises(ChunkedEncodingError) as exc:
+            requests.get("http://example.com/api/123")
+
+        assert "IncompleteRead" in str(exc.value)
+
+    original_init = getattr(requests.packages.urllib3.HTTPResponse, "__init__")
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, enforce_content_length=True, **kwargs)
+
+    setattr(requests.packages.urllib3.HTTPResponse, "__init__", patched_init)
+
+    try:
+        run()
+        assert_reset()
+    finally:
+        setattr(requests.packages.urllib3.HTTPResponse, "__init__", original_init)
 
 
 def test_legacy_adding_headers():


### PR DESCRIPTION
Opposite to #396 we do not need to raise an exception.
Exception is raised directly by `requests` module

If `responses` selected this response as a match to request, then such response should be treated the same way as real response. That means it should reraise/pass all exceptions occurred in HTTP libraries. This will be an expected behavior

I made some research on `requests` and it looks like they wanted to add a new argument `enforce_content_length` to `request`, so far it is on hold till version 3.0, I added a comment in docstrings in tests

Closes #394 