### PR TITLE
Bump version to reflect changes on master branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ class PyTest(TestCommand):
 
 setup(
     name="responses",
-    version="0.14.0",
+    version="0.16.0",
     author="David Cramer",
     description=("A utility library for mocking out the `requests` Python library."),
     url="https://github.com/getsentry/responses",


### PR DESCRIPTION
The 0.15.0 release was not reflected in the change to the `setup.py` on master, which looks like it might be an issue with an automated release process.

I believe however that the correct version to have on master at the moment is 0.16.0 (or a pre-release/dev variant of it) so that installing with pip direct from Git works. Without this, pip clones the repo, compares the version to the currently installed version, and then chooses not to install the changes from master because of the version being lower.