### PR TITLE
chore(py2) Start removing python 2 support

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,5 +7,5 @@ targets:
   - name: pypi
   - name: github
 requireNames:
-  - /^responses-.+-py2.py3-none-any.whl$/
+  - /^responses-.+-py3-none-any.whl$/
   - /^responses-.+.tar.gz$/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
         requests-version: ['"requests>=2.0,<3.0"', '-U requests']
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ A utility library for mocking out the ``requests`` Python library.
 
 ..  note::
 
-    Responses requires Python 2.7 or newer, and requests >= 2.0
+    Responses requires Python 3.5 or newer, and requests >= 2.0
 
 
 Installing

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -18,10 +18,7 @@ from responses.matchers import json_params_matcher as _json_params_matcher
 from responses.matchers import urlencoded_params_matcher as _urlencoded_params_matcher
 from warnings import warn
 
-try:
-    from collections.abc import Sequence, Sized
-except ImportError:
-    from collections import Sequence, Sized
+from collections.abc import Sequence, Sized
 
 try:
     from requests.packages.urllib3.response import HTTPResponse
@@ -112,18 +109,12 @@ def _clean_unicode(url):
 
 
 def _cookies_from_headers(headers):
-    try:
-        import http.cookies as _cookies
+    import http.cookies as _cookies
 
-        resp_cookie = _cookies.SimpleCookie()
-        resp_cookie.load(headers["set-cookie"])
+    resp_cookie = _cookies.SimpleCookie()
+    resp_cookie.load(headers["set-cookie"])
 
-        cookies_dict = {name: v.value for name, v in resp_cookie.items()}
-    except (ImportError, AttributeError):
-        from cookies import Cookies
-
-        resp_cookies = Cookies.from_request(str(headers["set-cookie"]))
-        cookies_dict = {v.name: quote(str(v.value)) for _, v in resp_cookies.items()}
+    cookies_dict = {name: v.value for name, v in resp_cookie.items()}
     return cookiejar_from_dict(cookies_dict)
 
 
@@ -281,9 +272,6 @@ class BaseResponse(object):
         if _is_string(url):
             if _has_unicode(url):
                 url = _clean_unicode(url)
-                if not isinstance(other, six.text_type):
-                    other = other.encode("ascii").decode("utf8")
-
             if match_querystring:
                 normalize_url = parse_url(url).url
                 return self._url_matches_strict(normalize_url, other)

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -1,12 +1,8 @@
-import six
 import json as json_module
 
 from requests import PreparedRequest
 
-if six.PY2:
-    from urlparse import parse_qsl, urlparse
-else:
-    from urllib.parse import parse_qsl, urlparse
+from urllib.parse import parse_qsl, urlparse
 
 
 try:

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 import inspect
 import os
 import re
-import six
 from io import BufferedReader, BytesIO
 
 import pytest
@@ -862,7 +861,6 @@ def test_activate_mock_interaction():
     assert isinstance(value, Mock)
 
 
-@pytest.mark.skipif(six.PY2, reason="Cannot run in python2")
 def test_activate_doesnt_change_signature_with_return_type():
     def test_function(a, b=None):
         return a, b
@@ -1016,7 +1014,6 @@ def test_response_callback():
     assert_reset()
 
 
-@pytest.mark.skipif(six.PY2, reason="re.compile works differntly in PY2")
 def test_response_filebody():
     """ Adds the possibility to use actual (binary) files as responses """
 
@@ -1581,7 +1578,7 @@ def test_custom_target(monkeypatch):
 
 
 def _quote(s):
-    return responses.quote(responses._ensure_str(s))
+    return responses.quote(str(s))
 
 
 def test_cookies_from_headers():

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,13 @@ if "test" in sys.argv:
     setup_requires.append("pytest")
 
 install_requires = [
-    "cookies; python_version < '3.4'",
-    "mock; python_version < '3.3'",
     "requests>=2.0",
     "urllib3>=1.25.10",
     "six",
 ]
 
 tests_require = [
-    "pytest>=4.6,<5.0; python_version < '3.5'",
-    "pytest>=4.6; python_version >= '3.5'",
+    "pytest>=4.6",
     "coverage >= 3.7.1, < 6.0.0",
     "pytest-cov",
     "pytest-localserver",
@@ -68,7 +65,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=["responses"],
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.5.*, <4",
     install_requires=install_requires,
     extras_require=extras_require,
     tests_require=tests_require,
@@ -81,8 +78,6 @@ setup(
         "Intended Audience :: System Administrators",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310,mypy
+envlist = py35,py36,py37,py38,py39,py310,mypy
 
 [testenv]
 extras = tests


### PR DESCRIPTION
0.17 will start to remove support for Python 2. There is more work to be done to inline types and fully adopt py3 idioms but that can be done separately.

This first step removes python 2 from the CI matrix and removes most of the compatibility shim code.