### PR TITLE
Add deprecation warning for python 2.7

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.17.0
 ------
 
+* This release is the last one to support Python 2.7.
 * Fixed issue when `response.iter_content` when `chunk_size=None` entered infinite loop
 * Fixed issue when `passthru_prefixes` persisted across tests.
   Now `add_passthru` is valid only within a context manager or for a single function and

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -77,6 +77,13 @@ _real_send = HTTPAdapter.send
 
 logger = logging.getLogger("responses")
 
+if six.PY2:
+    warn(
+        "Support for Python 2.7 is being removed from the next release of responses. "
+        "Pin your dependency to responses==0.17 or lower.",
+        DeprecationWarning,
+    )
+
 
 def urlencoded_params_matcher(params):
     warn(


### PR DESCRIPTION
I'd like to drop python 2.7 support in a future release. 0.17.0 will be the last version of responses to support python 2.7