### PR TITLE
Clean up python 2.7, 3.5, 3.6

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,5 +7,5 @@ targets:
   - name: pypi
   - name: github
 requireNames:
-  - /^responses-.+-py2.py3-none-any.whl$/
+  - /^responses-.+-py3-none-any.whl$/
   - /^responses-.+.tar.gz$/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         requests-version: ['"requests>=2.0,<3.0"', '-U requests']
 
     steps:

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.18.0
 ------
 
+* Dropped support of Python 2.7, 3.5, 3.6
+
 0.17.0
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ A utility library for mocking out the ``requests`` Python library.
 
 ..  note::
 
-    Responses requires Python 2.7 or newer, and requests >= 2.0
+    Responses requires Python 3.7 or newer, and requests >= 2.0
 
 
 Installing

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -20,10 +20,7 @@ from responses.registries import FirstMatchRegistry
 from responses.matchers import query_string_matcher as _query_string_matcher
 from warnings import warn
 
-try:
-    from collections.abc import Sequence, Sized
-except ImportError:
-    from collections import Sequence, Sized
+from collections.abc import Sequence, Sized
 
 try:
     from requests.packages.urllib3.response import HTTPResponse
@@ -102,8 +99,6 @@ def _clean_unicode(url):
         url = urlunsplit(urllist)
 
     # Clean up path/query/params, which use url-encoding to handle unicode chars
-    if isinstance(url.encode("utf8"), str):
-        url = url.encode("utf8")
     chars = list(url)
     for i, x in enumerate(chars):
         if ord(x) > 128:
@@ -315,8 +310,6 @@ class BaseResponse(object):
         if _is_string(url):
             if _has_unicode(url):
                 url = _clean_unicode(url)
-                if not isinstance(other, str):
-                    other = other.encode("ascii").decode("utf8")
 
             return _get_url_and_path(url) == _get_url_and_path(other)
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 
 import _io
 from http import client
+from http import cookies
 import inspect
 import json as json_module
 import logging
@@ -112,20 +113,10 @@ def _ensure_str(s):
 
 
 def _cookies_from_headers(headers):
-    try:
-        import http.cookies as _cookies
+    resp_cookie = cookies.SimpleCookie()
+    resp_cookie.load(headers["set-cookie"])
+    cookies_dict = {name: v.value for name, v in resp_cookie.items()}
 
-        resp_cookie = _cookies.SimpleCookie()
-        resp_cookie.load(headers["set-cookie"])
-
-        cookies_dict = {name: v.value for name, v in resp_cookie.items()}
-    except (ImportError, AttributeError):
-        from cookies import Cookies
-
-        resp_cookies = Cookies.from_request(_ensure_str(headers["set-cookie"]))
-        cookies_dict = {
-            v.name: quote(_ensure_str(v.value)) for _, v in resp_cookies.items()
-        }
     return cookiejar_from_dict(cookies_dict)
 
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -8,7 +8,6 @@ import logging
 import re
 from itertools import groupby
 
-import six
 
 from collections import namedtuple
 from functools import update_wrapper
@@ -179,7 +178,7 @@ def get_wrapped(func, responses, registry=None):
         responses._set_registry(registry)
 
     evaldict = {"func": func, "responses": responses}
-    six.exec_(
+    exec(
         _wrapper_template % {"wrapper_args": wrapper_args, "func_args": func_args},
         evaldict,
     )

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -53,11 +53,7 @@ from io import BytesIO as BufferIO
 from unittest import mock as std_mock
 
 
-try:
-    Pattern = re._pattern_type
-except AttributeError:
-    # Python 3.7
-    Pattern = re.Pattern
+Pattern = re.Pattern
 
 UNSET = object()
 

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -1,4 +1,3 @@
-import six
 import json as json_module
 
 from requests import PreparedRequest
@@ -162,8 +161,6 @@ def query_string_matcher(query):
     :param query: (str), same as constructed by request
     :return: (func) matcher
     """
-    if six.PY2 and isinstance(query, unicode):  # noqa: F821
-        query = query.encode("utf8")
 
     def match(request):
         reason = ""

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -2,22 +2,9 @@ import six
 import json as json_module
 
 from requests import PreparedRequest
-
-if six.PY2:
-    from urlparse import parse_qsl, urlparse
-else:
-    from urllib.parse import parse_qsl, urlparse
-
-
-try:
-    from requests.packages.urllib3.util.url import parse_url
-except ImportError:  # pragma: no cover
-    from urllib3.util.url import parse_url  # pragma: no cover
-
-try:
-    from json.decoder import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
+from urllib.parse import parse_qsl, urlparse
+from requests.packages.urllib3.util.url import parse_url
+from json.decoder import JSONDecodeError
 
 
 def _create_key_val_str(input_dict):

--- a/responses/test_matchers.py
+++ b/responses/test_matchers.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import, print_function, division, unicode_literals
 
-import six
-from sys import version_info
-
 import pytest
 import requests
 import responses
@@ -182,11 +179,9 @@ def test_request_matches_params():
         }
         resp = requests.get(url, params=params)
 
-        if six.PY3 and version_info[1] >= 7:
-            # only after py 3.7 dictionaries are ordered, so we can check URL
-            constructed_url = r"http://example.com/test?I+am=a+big+test&hello=world"
-            assert resp.url == constructed_url
-            assert resp.request.url == constructed_url
+        constructed_url = r"http://example.com/test?I+am=a+big+test&hello=world"
+        assert resp.url == constructed_url
+        assert resp.request.url == constructed_url
 
         resp_params = getattr(resp.request, "params")
         assert resp_params == params
@@ -349,24 +344,15 @@ def test_multipart_matcher_fail():
 
             msg = str(excinfo.value)
             assert "multipart/form-data doesn't match. Request body differs." in msg
-            if six.PY2:
-                assert (
-                    '\r\nContent-Disposition: form-data; name="file_name"; '
-                    'filename="file_name"\r\n\r\nOld World!\r\n'
-                ) in msg
-                assert (
-                    '\r\nContent-Disposition: form-data; name="file_name"; '
-                    'filename="file_name"\r\n\r\nNew World!\r\n'
-                ) in msg
-            else:
-                assert (
-                    r'\r\nContent-Disposition: form-data; name="file_name"; '
-                    r'filename="file_name"\r\n\r\nOld World!\r\n'
-                ) in msg
-                assert (
-                    r'\r\nContent-Disposition: form-data; name="file_name"; '
-                    r'filename="file_name"\r\n\r\nNew World!\r\n'
-                ) in msg
+
+            assert (
+                r'\r\nContent-Disposition: form-data; name="file_name"; '
+                r'filename="file_name"\r\n\r\nOld World!\r\n'
+            ) in msg
+            assert (
+                r'\r\nContent-Disposition: form-data; name="file_name"; '
+                r'filename="file_name"\r\n\r\nNew World!\r\n'
+            ) in msg
 
         # x-www-form-urlencoded request
         with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -842,14 +842,9 @@ def test_activate_mock_interaction():
         return mock_stdout
 
     decorated_test_function = responses.activate(test_function)
-    if hasattr(inspect, "signature"):
-        assert inspect.signature(test_function) == inspect.signature(
-            decorated_test_function
-        )
-    else:
-        assert inspect.getargspec(test_function) == inspect.getargspec(
-            decorated_test_function
-        )
+    assert inspect.signature(test_function) == inspect.signature(
+        decorated_test_function
+    )
 
     value = test_function()
     assert isinstance(value, Mock)

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -805,14 +805,10 @@ def test_activate_doesnt_change_signature():
         return (a, b)
 
     decorated_test_function = responses.activate(test_function)
-    if hasattr(inspect, "signature"):
-        assert inspect.signature(test_function) == inspect.signature(
-            decorated_test_function
-        )
-    else:
-        assert inspect.getargspec(test_function) == inspect.getargspec(
-            decorated_test_function
-        )
+    assert inspect.signature(test_function) == inspect.signature(
+        decorated_test_function
+    )
+
     assert decorated_test_function(1, 2) == test_function(1, 2)
     assert decorated_test_function(3) == test_function(3)
 

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -1576,10 +1576,10 @@ def test_passthru_does_not_persist_across_tests(httpserver):
         responses.add_passthru(re.compile(".*"))
         try:
             response = requests.get("https://example.com")
-        except ConnectionError as err:
-            if "Failed to establish" in str(err):
-                pytest.skip("Cannot resolve DNS for example.com")
-            raise err
+        except ConnectionError as err:  # pragma: no cover
+            if "Failed to establish" in str(err):  # pragma: no cover
+                pytest.skip("Cannot resolve DNS for example.com")  # pragma: no cover
+            raise err  # pragma: no cover
 
         assert response.status_code == 200
 

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 import inspect
 import os
 import re
-import six
 from io import BufferedReader, BytesIO
 
 import pytest
@@ -863,7 +862,6 @@ def test_activate_mock_interaction():
     assert isinstance(value, Mock)
 
 
-@pytest.mark.skipif(six.PY2, reason="Cannot run in python2")
 def test_activate_doesnt_change_signature_with_return_type():
     def test_function(a, b=None):
         return a, b
@@ -1017,7 +1015,6 @@ def test_response_callback():
     assert_reset()
 
 
-@pytest.mark.skipif(six.PY2, reason="re.compile works differntly in PY2")
 def test_response_filebody():
     """ Adds the possibility to use actual (binary) files as responses """
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ if "test" in sys.argv:
 install_requires = [
     "requests>=2.0",
     "urllib3>=1.25.10",
-    "six",
 ]
 
 tests_require = [
@@ -33,7 +32,6 @@ tests_require = [
     "flake8",
     "types-mock",
     "types-requests",
-    "types-six",
     "mypy",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -20,24 +20,21 @@ if "test" in sys.argv:
     setup_requires.append("pytest")
 
 install_requires = [
-    "cookies; python_version < '3.4'",
-    "mock; python_version < '3.3'",
     "requests>=2.0",
     "urllib3>=1.25.10",
     "six",
 ]
 
 tests_require = [
-    "pytest>=4.6,<5.0; python_version < '3.5'",
-    "pytest>=4.6; python_version >= '3.5'",
-    "coverage >= 3.7.1, < 6.0.0",
+    "pytest>=4.6",
+    "coverage >= 3.7.1",
     "pytest-cov",
     "pytest-localserver",
     "flake8",
     "types-mock",
     "types-requests",
     "types-six",
-    "mypy; python_version >= '3.5'",
+    "mypy",
 ]
 
 extras_require = {"tests": tests_require}
@@ -68,7 +65,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=["responses"],
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.7",
     install_requires=install_requires,
     extras_require=extras_require,
     tests_require=tests_require,
@@ -81,11 +78,7 @@ setup(
         "Intended Audience :: System Administrators",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310,mypy,precom
+envlist = py37,py38,py39,py310,mypy,precom
 
 [testenv]
 extras = tests


### PR DESCRIPTION
See EOL matrix: https://endoflife.date/python
2.7, 3.5, 3.6 are all EOL


remove SIX module completely
update setup.py
update tox

compared to #442:
python 3.5 and 3.6 are removed as EOL
completely removes `six` module
full code coverage 

