### PR TITLE
fix(build) Fix new mypy errors caused by typestub updates

### DIFF
--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -21,7 +21,7 @@ from requests.cookies import RequestsCookieJar
 from typing_extensions import Literal
 from unittest import mock as std_mock
 from urllib.parse import quote as quote
-from urllib3.response import HTTPHeaderDict
+from urllib3.response import HTTPHeaderDict # type: ignore # Not currently exposed in typestubs.
 from .matchers import urlencoded_params_matcher, json_params_matcher
 from .registries import FirstMatchRegistry
 
@@ -90,7 +90,7 @@ class BaseResponse:
         self, url: Union[Pattern[str], str], other: str, match_querystring: bool = ...
     ) -> bool: ...
     def _url_matches_strict(self, url: str, other: str) -> bool: ...
-    def get_headers(self) -> HTTPHeaderDict: ...  # type: ignore [no-any-unimported]
+    def get_headers(self) -> HTTPHeaderDict: ...  # type: ignore
     def get_response(self, request: PreparedRequest) -> None: ...
     def matches(self, request: PreparedRequest) -> Tuple[bool, str]: ...
 

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -1238,14 +1238,17 @@ def test_content_length_error(monkeypatch):
 
         assert "IncompleteRead" in str(exc.value)
 
-    original_init = getattr(requests.packages.urllib3.HTTPResponse, "__init__")
+    # Type errors here and on 1250 are ignored because the stubs for requests
+    # are off https://github.com/python/typeshed/blob/f8501d33c737482a829c6db557a0be26895c5941
+    #   /stubs/requests/requests/packages/__init__.pyi#L1
+    original_init = getattr(requests.packages.urllib3.HTTPResponse, "__init__")  # type: ignore
 
     def patched_init(self, *args, **kwargs):
         kwargs["enforce_content_length"] = True
         original_init(self, *args, **kwargs)
 
     monkeypatch.setattr(
-        requests.packages.urllib3.HTTPResponse, "__init__", patched_init
+        requests.packages.urllib3.HTTPResponse, "__init__", patched_init  # type: ignore
     )
 
     run()


### PR DESCRIPTION
The typestubs for requests and urllib3 have been updated but they are not complete and cause errors for us.