### PR TITLE
fix 468

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 ------
 
 * Dropped support of Python 2.7, 3.5, 3.6
+* Fixed issue with type annotation for `responses.activate` decorator. See #468
 * Removed internal `_is_string` and `_ensure_str` functions
 * Removed internal `_quote` from `test_responses.py`
 

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -12,7 +12,9 @@ from typing import (
     List,
     Tuple,
     Union,
-    Iterable
+    Iterable,
+    overload,
+    Type
 )
 from io import BufferedReader, BytesIO
 from re import Pattern
@@ -23,7 +25,6 @@ from unittest import mock as std_mock
 from urllib.parse import quote as quote
 from urllib3.response import HTTPHeaderDict # type: ignore # Not currently exposed in typestubs.
 from .matchers import urlencoded_params_matcher, json_params_matcher
-from .registries import FirstMatchRegistry
 
 
 def _clean_unicode(url: str) -> str: ...
@@ -275,7 +276,15 @@ class _Registered(Protocol):
     def __call__(self) -> List[Response]: ...
 
 
-activate: Any
+class _Activate(Protocol):
+    @overload
+    def __call__(self, func: _F = ...) -> _F: ...
+
+    @overload
+    def __call__(self, registry: Type[Any] = ...) -> Callable[['_F'], '_F']: ...
+
+
+activate: _Activate
 add: _Add
 add_callback: _AddCallback
 add_passthru: _AddPassthru

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -16,6 +16,7 @@ from typing import (
     overload,
     Type
 )
+
 from io import BufferedReader, BytesIO
 from re import Pattern
 from requests.adapters import HTTPResponse, PreparedRequest
@@ -277,11 +278,15 @@ class _Registered(Protocol):
 
 
 class _Activate(Protocol):
+    # see https://github.com/getsentry/responses/pull/469 for more details
+
     @overload
     def __call__(self, func: _F = ...) -> _F: ...
+    # use this overload for scenario when 'responses.activate' is used
 
     @overload
     def __call__(self, registry: Type[Any] = ...) -> Callable[['_F'], '_F']: ...
+    # use this overload for scenario when 'responses.activate(registry=)' is used
 
 
 activate: _Activate


### PR DESCRIPTION
closes #468 

Issue is caused by new behavior of decorator, which allows to run it as static `responses.activate` as well as a function call like `responses.activate(registries=)`. `mypy` cannot treat it really well. See https://github.com/samuelcolvin/pydantic/issues/2052


In order to avoid this, we will need to overload decorator definition in typing.