### PR TITLE
Fix 464

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@
 * Removed internal `_is_string` and `_ensure_str` functions
 * Removed internal `_quote` from `test_responses.py`
 * Removed internal `_matches` attribute of `RequestsMock` object.
+* Fix issue when Deprecation Warning was raised with default arguments
+  in `responses.add_callback`. See #464
 
 0.17.0
 ------
@@ -14,7 +16,7 @@
 * Fixed issue when `passthru_prefixes` persisted across tests.
   Now `add_passthru` is valid only within a context manager or for a single function and
   cleared on exit
-* Deprecate `match_querystring` argument in `Response`` and `CallbackResponse`.
+* Deprecate `match_querystring` argument in `Response` and `CallbackResponse`.
   Use `responses.matchers.query_param_matcher` or `responses.matchers.query_string_matcher`
 * Added support for non-UTF-8 bytes in `responses.matchers.multipart_matcher`
 * Added `responses.registries`. Now user can create custom registries to

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@
 * Removed internal `_quote` from `test_responses.py`
 * Removed internal `_matches` attribute of `RequestsMock` object.
 * Fix issue when Deprecation Warning was raised with default arguments
-  in `responses.add_callback`. See #464
+  in `responses.add_callback` due to `match_querystring`. See #464
 
 0.17.0
 ------

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -62,6 +62,15 @@ _real_send = HTTPAdapter.send
 logger = logging.getLogger("responses")
 
 
+class FalseBool:
+    # used for backwards compatibility, see
+    # https://github.com/getsentry/responses/issues/464
+    def __bool__(self):
+        return False
+
+    __nonzero__ = __bool__
+
+
 def urlencoded_params_matcher(params):
     warn(
         "Function is deprecated. Use 'from responses.matchers import urlencoded_params_matcher'",
@@ -277,14 +286,15 @@ class BaseResponse(object):
             return False
 
         if match_querystring_argument is not None:
-            warn(
-                (
-                    "Argument 'match_querystring' is deprecated. "
-                    "Use 'responses.matchers.query_param_matcher' or "
-                    "'responses.matchers.query_string_matcher'"
-                ),
-                DeprecationWarning,
-            )
+            if not isinstance(match_querystring_argument, FalseBool):
+                warn(
+                    (
+                        "Argument 'match_querystring' is deprecated. "
+                        "Use 'responses.matchers.query_param_matcher' or "
+                        "'responses.matchers.query_string_matcher'"
+                    ),
+                    DeprecationWarning,
+                )
             return match_querystring_argument
 
         return bool(urlparse(self.url).query)
@@ -659,7 +669,7 @@ class RequestsMock(object):
         method,
         url,
         callback,
-        match_querystring=False,
+        match_querystring=FalseBool(),
         content_type="text/plain",
         match=(),
     ):

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -22,6 +22,7 @@ from typing_extensions import Literal
 from unittest import mock as std_mock
 from urllib.parse import quote as quote
 from urllib3.response import HTTPHeaderDict # type: ignore # Not currently exposed in typestubs.
+
 from .matchers import urlencoded_params_matcher, json_params_matcher
 from .registries import FirstMatchRegistry
 
@@ -60,6 +61,9 @@ class CallList(Sequence[Call], Sized):
     def __getitem__(self, idx: int) -> Call: ...  # type: ignore [override]
     def add(self, request: PreparedRequest, response: _Body) -> None: ...
     def reset(self) -> None: ...
+
+class FalseBool:
+    def __bool__(self) -> bool: ...
 
 class BaseResponse:
     passthrough: bool = ...
@@ -130,7 +134,7 @@ class CallbackResponse(BaseResponse):
         callback: Callable[[Any], Any],
         stream: bool = ...,
         content_type: Optional[str] = ...,
-        match_querystring: bool = ...,
+        match_querystring: Union[bool, FalseBool] = ...,
         match: MatcherIterable = ...,
     ) -> None: ...
     def get_response(  # type: ignore [override]

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -592,11 +592,11 @@ def test_callback_match_querystring_default_false():
         assert resp.status_code == status
         assert "foo" in resp.headers
 
-    from _pytest.outcomes import Failed
+    with pytest.warns(None) as record:
+        run()
 
-    with pytest.raises(Failed):
-        with pytest.deprecated_call():
-            run()
+    # check that no deprecation warning was raised
+    assert not record
 
     assert_reset()
 


### PR DESCRIPTION
closes #464 


mock up with custom `False`

this allows to preserve deprecation warning and backwards compatibility with 0.16