### PR TITLE
Remove unused field

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@
 * Dropped support of Python 2.7, 3.5, 3.6
 * Removed internal `_is_string` and `_ensure_str` functions
 * Removed internal `_quote` from `test_responses.py`
-* Removed internal `_matches` from `__init__.py`
+* Removed internal `_matches` attribute of `RequestsMock` object.
 
 0.17.0
 ------

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 * Dropped support of Python 2.7, 3.5, 3.6
 * Removed internal `_is_string` and `_ensure_str` functions
 * Removed internal `_quote` from `test_responses.py`
+* Removed internal `_matches` from `__init__.py`
 
 0.17.0
 ------

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -521,7 +521,6 @@ class RequestsMock(object):
         self.passthru_prefixes = tuple(passthru_prefixes)
         self.target = target
         self._patcher = None
-        self._matches = []
 
     def _get_registry(self):
         return self._registry


### PR DESCRIPTION
Per the discussion in #467 - this field is no longer used anywhere, so should be safe to remove.
All tests still pass after this change (locally..)
