### PR TITLE
remove parallel requests branch test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        requests-version: ['"requests>=2.0,<3.0"', '-U requests']
+        requests-version: ['"requests>=2.0,<3.0"']
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if "test" in sys.argv:
     setup_requires.append("pytest")
 
 install_requires = [
-    "requests>=2.0",
+    "requests>=2.0,<3.0",
     "urllib3>=1.25.10",
 ]
 


### PR DESCRIPTION
basically, we always run on the same version of requests. Just remove redundant pipeline.

if in some time requests 3.X will come, we can update. So far requests 3 project is frozen and is not updated since 4 years.

Even if it will come, we will need to test it first, before releasing to wider audience. Thus, fix `requests` version in `setup.py`