### PR TITLE
Fix duplicate content-type silently failing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 
 * Expose `get_registry()` method of `RequestsMock` object. Replaces internal `_get_registry()`.
 * Added support for `async/await` functions.
+* An error is now raised when both `content_type` and `headers[content-type]` are provided as parameters.
 
 0.18.0
 ------

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -566,7 +566,7 @@ class RequestsMock(object):
         if adding_headers is not None:
             kwargs.setdefault("headers", adding_headers)
         if "content_type" in kwargs and "headers" in kwargs:
-            header_keys = list(map(lambda x: x.lower(), kwargs["headers"].keys()))
+            header_keys = [header.lower() for header in kwargs["headers"]]
             if "content-type" in header_keys:
                 raise RuntimeError(
                     "You cannot define both `content_type` and `headers[Content-Type]`."

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -565,6 +565,13 @@ class RequestsMock(object):
 
         if adding_headers is not None:
             kwargs.setdefault("headers", adding_headers)
+        if "content_type" in kwargs and "headers" in kwargs:
+            header_keys = list(map(lambda x: x.lower(), kwargs["headers"].keys()))
+            if "content-type" in header_keys:
+                raise RuntimeError(
+                    "You cannot define both `content_type` and `headers[Content-Type]`."
+                    " Using the `content_type` kwarg is recommended."
+                )
 
         self._registry.add(Response(method=method, url=url, body=body, **kwargs))
 

--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -1319,6 +1319,26 @@ def test_legacy_adding_headers():
     assert_reset()
 
 
+def test_legacy_adding_headers_with_content_type():
+    @responses.activate
+    def run():
+        with pytest.raises(RuntimeError) as excinfo:
+            responses.add(
+                responses.GET,
+                "http://example.com",
+                body="test",
+                content_type="text/html",
+                adding_headers={"Content-Type": "text/html; charset=utf-8"},
+            )
+        assert (
+            "You cannot define both `content_type` and `headers[Content-Type]`"
+            in str(excinfo.value)
+        )
+
+    run()
+    assert_reset()
+
+
 def test_auto_calculate_content_length_string_body():
     @responses.activate
     def run():


### PR DESCRIPTION
When both the `content_type` keyword argument and the `Content-Type` header are defined we have an ambiguous set of parameters. Raise an error to let the developer known they have made an invalid method call.

Fixes #483