### PR TITLE
fix test with warnings

### DIFF
--- a/responses/test_responses.py
+++ b/responses/test_responses.py
@@ -3,6 +3,7 @@
 import inspect
 import os
 import re
+import warnings
 from io import BufferedReader
 from io import BytesIO
 from unittest.mock import Mock
@@ -587,11 +588,9 @@ def test_callback_match_querystring_default_false():
         assert resp.status_code == status
         assert "foo" in resp.headers
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         run()
-
-    # check that no deprecation warning was raised
-    assert not record
 
     assert_reset()
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
 ]
 
 tests_require = [
-    "pytest>=4.6",
+    "pytest>=7.0.0",
     "coverage >= 6.0.0",
     "pytest-cov",
     "pytest-asyncio",


### PR DESCRIPTION
pipe on master failed: https://github.com/getsentry/responses/runs/5068593004?check_suite_focus=true

new version of pytest was released, now we cannot check warns with None, there is a new method:
https://docs.pytest.org/en/7.0.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests