### PR TITLE
ensure tests are present in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.rst CHANGES LICENSE
-include test_responses.py test_matchers.py test_registries.py
+recursive-include responses *.py
 include **/*.pyi
 include tox.ini
 global-exclude *~


### PR DESCRIPTION
This help Linux distro packaging as packagers usually use the test suite to they are shipping only functional releases to users.

This is likely due to commit 8a8f3422f93434c766f02fd0f1354c27ef538e25 by @beliaev-maksim (#474).