### PR TITLE
mbeliaev/assert call count

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@
 ------
 
 * Removed internal `_cookies_from_headers` function
+* Now `add`, `upsert`, `replace` methods return registered response.
+  `remove` method returns list of removed responses.
 
 0.20.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -800,6 +800,42 @@ the ``assert_all_requests_are_fired`` value:
 Assert Request Call Count
 -------------------------
 
+Assert based on ``Response`` object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each ``Response`` object has ``call_count`` attribute that could be inspected
+to check how many times each request was matched.
+
+.. code-block:: python
+
+    @responses.activate
+    def test_call_count_with_matcher():
+
+        rsp = responses.add(
+            responses.GET,
+            "http://www.example.com",
+            match=(matchers.query_param_matcher({}),),
+        )
+        rsp2 = responses.add(
+            responses.GET,
+            "http://www.example.com",
+            match=(matchers.query_param_matcher({"hello": "world"}),),
+            status=777,
+        )
+        requests.get("http://www.example.com")
+        resp1 = requests.get("http://www.example.com")
+        requests.get("http://www.example.com?hello=world")
+        resp2 = requests.get("http://www.example.com?hello=world")
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 777
+
+        assert rsp.call_count == 2
+        assert rsp2.call_count == 2
+
+Assert based on the exact URL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Assert that the request was called exactly n times.
 
 .. code-block:: python
@@ -818,6 +854,16 @@ Assert that the request was called exactly n times.
         with pytest.raises(AssertionError) as excinfo:
             responses.assert_call_count("http://example.com", 1)
         assert "Expected URL 'http://example.com' to be called 1 times. Called 2 times." in str(excinfo.value)
+
+    @responses.activate
+    def test_assert_call_count_always_match_qs():
+        responses.add(responses.GET, "http://www.example.com")
+        requests.get("http://www.example.com")
+        requests.get("http://www.example.com?hello=world")
+
+        # One call on each url, querystring is matched by default
+        responses.assert_call_count("http://www.example.com", 1) is True
+        responses.assert_call_count("http://www.example.com?hello=world", 1) is True
 
 
 Multiple Responses

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -575,7 +575,7 @@ class RequestsMock(object):
         """
         if isinstance(method, BaseResponse):
             self._registry.add(method)
-            return
+            return method
 
         if adding_headers is not None:
             kwargs.setdefault("headers", adding_headers)
@@ -587,28 +587,29 @@ class RequestsMock(object):
                     " Using the `content_type` kwarg is recommended."
                 )
 
-        self._registry.add(Response(method=method, url=url, body=body, **kwargs))
+        response = Response(method=method, url=url, body=body, **kwargs)
+        return self._registry.add(response)
 
     def delete(self, *args, **kwargs):
-        self.add(DELETE, *args, **kwargs)
+        return self.add(DELETE, *args, **kwargs)
 
     def get(self, *args, **kwargs):
-        self.add(GET, *args, **kwargs)
+        return self.add(GET, *args, **kwargs)
 
     def head(self, *args, **kwargs):
-        self.add(HEAD, *args, **kwargs)
+        return self.add(HEAD, *args, **kwargs)
 
     def options(self, *args, **kwargs):
-        self.add(OPTIONS, *args, **kwargs)
+        return self.add(OPTIONS, *args, **kwargs)
 
     def patch(self, *args, **kwargs):
-        self.add(PATCH, *args, **kwargs)
+        return self.add(PATCH, *args, **kwargs)
 
     def post(self, *args, **kwargs):
-        self.add(POST, *args, **kwargs)
+        return self.add(POST, *args, **kwargs)
 
     def put(self, *args, **kwargs):
-        self.add(PUT, *args, **kwargs)
+        return self.add(PUT, *args, **kwargs)
 
     def add_passthru(self, prefix):
         """
@@ -644,7 +645,7 @@ class RequestsMock(object):
         else:
             response = BaseResponse(method=method_or_response, url=url)
 
-        self._registry.remove(response)
+        return self._registry.remove(response)
 
     def replace(self, method_or_response=None, url=None, body="", *args, **kwargs):
         """
@@ -661,7 +662,7 @@ class RequestsMock(object):
         else:
             response = Response(method=method_or_response, url=url, body=body, **kwargs)
 
-        self._registry.replace(response)
+        return self._registry.replace(response)
 
     def upsert(self, method_or_response=None, url=None, body="", *args, **kwargs):
         """
@@ -674,9 +675,9 @@ class RequestsMock(object):
         >>> responses.upsert(responses.GET, 'http://example.org', json={'data': 2})
         """
         try:
-            self.replace(method_or_response, url, body, *args, **kwargs)
+            return self.replace(method_or_response, url, body, *args, **kwargs)
         except ValueError:
-            self.add(method_or_response, url, body, *args, **kwargs)
+            return self.add(method_or_response, url, body, *args, **kwargs)
 
     def add_callback(
         self,

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -574,8 +574,7 @@ class RequestsMock(object):
 
         """
         if isinstance(method, BaseResponse):
-            self._registry.add(method)
-            return method
+            return self._registry.add(method)
 
         if adding_headers is not None:
             kwargs.setdefault("headers", adding_headers)

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -230,7 +230,7 @@ class _Add(Protocol):
         adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: MatcherIterable = ...,
-    ) -> None: ...
+    ) -> BaseResponse: ...
 
 class _Shortcut(Protocol):
     def __call__(
@@ -269,7 +269,7 @@ class _Remove(Protocol):
         self,
         method_or_response: Optional[Union[str, BaseResponse]] = ...,
         url: Optional[Union[Pattern[str], str]] = ...,
-    ) -> None: ...
+    ) -> List[BaseResponse]: ...
 
 class _Replace(Protocol):
     def __call__(
@@ -285,7 +285,7 @@ class _Replace(Protocol):
         adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: MatcherIterable = ...,
-    ) -> None: ...
+    ) -> BaseResponse: ...
 
 class _Upsert(Protocol):
     def __call__(
@@ -301,7 +301,7 @@ class _Upsert(Protocol):
         adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: MatcherIterable = ...,
-    ) -> None: ...
+    ) -> BaseResponse: ...
 
 class _Registered(Protocol):
     def __call__(self) -> List[Response]: ...

--- a/responses/__init__.pyi
+++ b/responses/__init__.pyi
@@ -246,7 +246,7 @@ class _Shortcut(Protocol):
         adding_headers: HeaderSet = ...,
         match_querystring: bool = ...,
         match: MatcherIterable = ...,
-    ) -> None: ...
+    ) -> BaseResponse: ...
 
 class _AddCallback(Protocol):
     def __call__(

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1831,6 +1831,50 @@ def test_assert_call_count(url):
     assert_reset()
 
 
+def test_call_count_with_matcher():
+    @responses.activate
+    def run():
+        rsp = responses.add(
+            responses.GET,
+            "http://www.example.com",
+            match=(matchers.query_param_matcher({}),),
+        )
+        rsp2 = responses.add(
+            responses.GET,
+            "http://www.example.com",
+            match=(matchers.query_param_matcher({"hello": "world"}),),
+            status=777,
+        )
+        requests.get("http://www.example.com")
+        resp1 = requests.get("http://www.example.com")
+        requests.get("http://www.example.com?hello=world")
+        resp2 = requests.get("http://www.example.com?hello=world")
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 777
+
+        assert rsp.call_count == 2
+        assert rsp2.call_count == 2
+
+    run()
+    assert_reset()
+
+
+def test_call_count_without_matcher():
+    @responses.activate
+    def run():
+        rsp = responses.add(responses.GET, "http://www.example.com")
+        requests.get("http://www.example.com")
+        requests.get("http://www.example.com")
+        requests.get("http://www.example.com?hello=world")
+        requests.get("http://www.example.com?hello=world")
+
+        assert rsp.call_count == 4
+
+    run()
+    assert_reset()
+
+
 def test_fail_request_error():
     """
     Validate that exception is raised if request URL/Method/kwargs don't match


### PR DESCRIPTION
closes #335

Considering evolved functionality of `matchers` I do not see it valuable to continue expanding `assert_call_count`. I believe more preferable will be to inspect `Response` objects, since they include matchers and all further functionality