### PR TITLE
change pytest fixture to httpserver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ tests_require = [
     "coverage >= 6.0.0",
     "pytest-cov",
     "pytest-asyncio",
-    "pytest-localserver",
+    "pytest-httpserver",
     "flake8",
     "types-requests",
     "mypy",


### PR DESCRIPTION
switch pytest fixture because httpserver is a way more powerful compared to localserver and has a better documentation.

also, see https://github.com/pytest-dev/pytest-localserver/issues/43