### PR TITLE
build(setup.py): Add `project_urls` for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,12 @@ setup(
     author="David Cramer",
     description="A utility library for mocking out the `requests` Python library.",
     url="https://github.com/getsentry/responses",
+    project_urls={
+        "Bug Tracker": "https://github.com/getsentry/responses/issues",
+        "Changes": "https://github.com/getsentry/responses/blob/master/CHANGES",
+        "Documentation": "https://github.com/getsentry/responses/blob/master/README.rst",
+        "Source Code": "https://github.com/getsentry/responses",
+    },
     license="Apache 2.0",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
[`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) for _setup.py_

For the [PyPI page](https://pypi.python.org/pypi/responses/) 

![image](https://user-images.githubusercontent.com/26336/179227755-787c9f3b-813d-4026-81b5-e5cda20fc3ae.png)
