### PR TITLE
adjust error message when Retry is exhausted

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 * Add lists support as JSON objects in `json_params_matcher`. See #559
 * Added project links to pypi listing.
 * Fix `MaxRetryError` exception. Replace exception by `RetryError` according to `requests` implementation. See #572.
+* Adjust error message when `Retry` is exhausted. See #580.
 
 0.21.0
 ------

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1029,7 +1029,7 @@ class RequestsMock(object):
                 retries = retries.increment(
                     method=response.request.method,  # type: ignore[misc]
                     url=response.url,  # type: ignore[misc]
-                    response=response,  # type: ignore[misc]
+                    response=response.raw,  # type: ignore[misc]
                 )
                 return self._on_request(adapter, request, retries=retries, **kwargs)
             except MaxRetryError as e:

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -2450,6 +2450,23 @@ class TestMaxRetry:
         run()
         assert_reset()
 
+    def test_max_retries_exceed_msg(self):
+        @responses.activate(registry=registries.OrderedRegistry)
+        def run():
+            url = "https://example.com"
+            responses.get(url, body="Error", status=500)
+            responses.get(url, body="Error", status=500)
+
+            session = self.set_session(total=1)
+
+            with pytest.raises(RetryError) as err:
+                session.get(url)
+
+            assert "too many 500 error responses" in str(err.value)
+
+        run()
+        assert_reset()
+
     def test_adapter_retry_untouched(self):
         """Validate that every new request uses brand-new Retry object"""
 


### PR DESCRIPTION
related to #574 

After debugging I found the difference.
When not a raw response is provided, then error message will be `too many error responses`. While with raw response it is more explicit and mentions the error code: `too many 500 error responses`

I added tests that cover it.