### PR TITLE
Update `requests` dependency to the version of 2.22.0 or higher

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.22.0
 ------
 
+* Update `requests` dependency to the version of 2.22.0 or higher
 * [BETA] Added possibility to record responses to TOML files via `@_recorder.record(file_path="out.toml")` decorator.
 * Fix type for the `mock`'s patcher object. See #556
 * Fix type annotation for `CallList`

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 0.22.0
 ------
 
-* Update `requests` dependency to the version of 2.22.0 or higher
+* Update `requests` dependency to the version of 2.22.0 or higher. See #584.
 * [BETA] Added possibility to record responses to TOML files via `@_recorder.record(file_path="out.toml")` decorator.
 * Fix type for the `mock`'s patcher object. See #556
 * Fix type annotation for `CallList`

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ A utility library for mocking out the ``requests`` Python library.
 
 ..  note::
 
-    Responses requires Python 3.7 or newer, and requests >= 2.0
+    Responses requires Python 3.7 or newer, and requests >= 2.23.0
 
 
 Table of Contents

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ A utility library for mocking out the ``requests`` Python library.
 
 ..  note::
 
-    Responses requires Python 3.7 or newer, and requests >= 2.23.0
+    Responses requires Python 3.7 or newer, and requests >= 2.22.0
 
 
 Table of Contents

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools.command.test import test as TestCommand
 setup_requires = []
 
 install_requires = [
-    "requests>=2.0,<3.0",
+    "requests>=2.22.0,<3.0",
     "urllib3>=1.25.10",
     "toml",
     "types-toml",


### PR DESCRIPTION
library since a long time requires "urllib3>=1.25.10"
if we looks at `requests` source code for v2.21.0 https://github.com/psf/requests/releases/tag/v2.21.0

we will see that they require  'urllib3>=1.21.1,<1.25',
https://github.com/psf/requests/blob/5a1e738ea9c399c3f59977f2f98b083986d6037a/setup.py#L47

thus, update our dependency to the higher requests. Docs as well