### PR TITLE
Fix annotations of CallList

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.23.0
+------
+
+* Fix type annotations of `CallList`.
+
 0.22.0
 ------
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -230,6 +230,14 @@ class CallList(Sequence[Any], Sized):
     def __len__(self) -> int:
         return len(self._calls)
 
+    @overload
+    def __getitem__(self, idx: int) -> Call:
+        ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> List[Call]:
+        ...
+
     def __getitem__(self, idx: Union[int, slice]) -> Union[Call, List[Call]]:
         return self._calls[idx]
 


### PR DESCRIPTION
With 0.22.0, mypy started to complain about constructions `rsps.calls[0].request` with an error
```
Item "List[Call]" of "Union[Call, List[Call]]" has no attribute "request"  [union-attr]
```
because it wasn't able to differentiate between the return types. I added `overload` annotation to handle that.