### PR TITLE
Use tomllib/tomli/tomli-w instead of unmaintained toml [WIP]

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -25,7 +25,7 @@ from typing import Union
 from typing import overload
 from warnings import warn
 
-import toml as _toml
+import tomli as _toml
 from requests.adapters import HTTPAdapter
 from requests.adapters import MaxRetryError
 from requests.exceptions import ConnectionError
@@ -770,7 +770,7 @@ class RequestsMock(object):
     put = partialmethod(add, PUT)
 
     def _add_from_file(self, file_path: "Union[str, bytes, os.PathLike[Any]]") -> None:
-        with open(file_path) as file:
+        with open(file_path, "rb") as file:
             data = _toml.load(file)
 
         for rsp in data["responses"]:

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 import requests
-import toml
+import tomli as _toml
+import tomli_w
 
 import responses
 from responses import _recorder
@@ -94,8 +95,8 @@ class TestRecord:
 
         run()
 
-        with open(self.out_file) as file:
-            data = toml.load(file)
+        with open(self.out_file, "rb") as file:
+            data = _toml.load(file)
 
         assert data == get_data(httpserver.host, httpserver.port)
 
@@ -109,8 +110,8 @@ class TestReplay:
         assert not out_file.exists()
 
     def test_add_from_file(self):
-        with open("out.toml", "w") as file:
-            toml.dump(get_data("example.com", "8080"), file)
+        with open("out.toml", "wb") as file:
+            tomli_w.dump(get_data("example.com", "8080"), file)
 
         @responses.activate
         def run():

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup_requires = []
 install_requires = [
     "requests>=2.22.0,<3.0",
     "urllib3>=1.25.10",
-    "toml",
-    "types-toml",
+    "tomli",
+    "tomli-w",
     "typing_extensions; python_version < '3.8'",
 ]
 


### PR DESCRIPTION
Replace the `toml` dependency that is unmaintained (last release in 2020) and does not implement TOML 1.0 with more modern libraries. Use the built-in `tomllib` module to load .toml files on Python 3.11, and its drop-in replacement `tomli` package on older versions of Python. For writing .toml files, use the `tomli-w` package.