### PR TITLE
Upgrade StackAid action to pick up bugfix

### DIFF
--- a/.github/workflows/stackaid.yml
+++ b/.github/workflows/stackaid.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: stackaid/generate-stackaid-json@v1.8
+      - uses: stackaid/generate-stackaid-json@v1.9


### PR DESCRIPTION
We saw an empty commit in https://github.com/getsentry/responses/commit/1d285695ada0065aacf1e10f4d5e770279e16361. Fixed in https://github.com/stackaid/generate-stackaid-json/commit/bbccf9adf6ab4acd69aa979b0cdc7e93a5e83d78.