### PR TITLE
Add custom exception to be able to attach request to an attribute

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -36,6 +36,7 @@ from requests.adapters import MaxRetryError
 from requests.exceptions import ConnectionError
 from requests.exceptions import RetryError
 
+from responses.exceptions import ResponseException
 from responses.matchers import json_params_matcher as _json_params_matcher
 from responses.matchers import query_string_matcher as _query_string_matcher
 from responses.matchers import urlencoded_params_matcher as _urlencoded_params_matcher
@@ -569,7 +570,11 @@ class Response(BaseResponse):
 
     def get_response(self, request: "PreparedRequest") -> HTTPResponse:
         if self.body and isinstance(self.body, Exception):
-            raise self.body
+            raise ResponseException(
+                self.body.args[0],
+                response=self.body.response,
+                request=request,
+            )
 
         headers = self.get_headers()
         status = self.status

--- a/responses/exceptions.py
+++ b/responses/exceptions.py
@@ -1,0 +1,5 @@
+class ResponseException(Exception):
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.get("request")
+        self.response = kwargs.get("response")
+        super().__init__(*args)


### PR DESCRIPTION
Hello!

This PR applies the Maksim Beliaev's suggest about:

> [...] should we consider attaching an attribute to a custom exception?

in ticket https://github.com/getsentry/responses/issues/588

I'm not sure if these were the changes expected, let me know any change/test/doc required!

I appreciate any feedback, thank you so much!