### PR TITLE
chore(typing): Try MonkeyType on modules in responses codebase

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -673,7 +673,7 @@ class RequestsMock(object):
         passthru_prefixes: Tuple[str, ...] = (),
         target: str = "requests.adapters.HTTPAdapter.send",
         registry: Type[FirstMatchRegistry] = FirstMatchRegistry,
-    ):
+    ) -> None:
         self._calls: CallList = CallList()
         self.reset()
         self._registry: FirstMatchRegistry = registry()  # call only after reset


### PR DESCRIPTION
Attempt to use MonkeyType on responses.
Benefit seems minimal since this codebase already has lots of type hits.
