### PR TITLE
Fix assert_all_requests_are_fired not reseting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 * Fix type annotations of `CallList`. See #593
 * Replaced toml with tomli and tomli-w.
 * `request` object is attached to any custom exception provided as `Response` `body` argument. See #588
+* Fixed mocked responses leaking between tests when `assert_all_requests_are_fired` and a request was not fired.
 
 0.22.0
 ------

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -924,8 +924,10 @@ class RequestsMock(object):
 
     def __exit__(self, type: Any, value: Any, traceback: Any) -> bool:
         success = type is None
-        self.stop(allow_assert=success)
-        self.reset()
+        try:
+            self.stop(allow_assert=success)
+        finally:
+            self.reset()
         return success
 
     @overload

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1133,6 +1133,28 @@ def test_assert_all_requests_are_fired():
     assert_reset()
 
 
+def test_assert_all_requests_fired_multiple():
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_some_function():
+        # Not all mocks are called so we'll get an AssertionError
+        responses.add(responses.GET, "http://other_url", json={})
+        responses.add(responses.GET, "http://some_api", json={})
+        requests.get("http://some_api")
+
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_some_second_function():
+        # This should pass as mocks should be reset.
+        responses.add(responses.GET, "http://some_api", json={})
+        requests.get("http://some_api")
+
+    with pytest.raises(AssertionError):
+        test_some_function()
+    assert_reset()
+
+    test_some_second_function()
+    assert_reset()
+
+
 def test_allow_redirects_samehost():
     redirecting_url = "http://example.com"
     final_url_path = "/1"


### PR DESCRIPTION
When multiple tests use assert_all_requests_are_fired=True and a test fails because mocks were not called, those mocks should be reset when the context manager exits.

Fixes #619