### PR TITLE
Change default recorder format to YAML

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,9 +3,10 @@
 
 * Add Python 3.11 support
 * Fix type annotations of `CallList`. See #593
-* Replaced toml with tomli and tomli-w.
 * `request` object is attached to any custom exception provided as `Response` `body` argument. See #588
 * Fixed mocked responses leaking between tests when `assert_all_requests_are_fired` and a request was not fired.
+* [BETA] Default recorder format was changed to YAML.  Added `responses.RequestsMock._parse_response_file` and
+  `responses._recorder.Recorder.dump_to_file` methods that allow users to override default parser to eg toml, json
 
 0.22.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,10 @@ Record Responses to files
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can perform real requests to the server and ``responses`` will automatically record the output to the
-file. Recorded data is stored in `toml <https://toml.io>`_ format.
+file. Recorded data is stored in `YAML <https://yaml.org>`_ format.
 
-Apply ``@responses._recorder.record(file_path="out.toml")`` decorator to any function where you perform
-requests to record responses to ``out.toml`` file.
+Apply ``@responses._recorder.record(file_path="out.yaml")`` decorator to any function where you perform
+requests to record responses to ``out.yaml`` file.
 
 Following code
 
@@ -90,7 +90,7 @@ Following code
         rsp = requests.get("https://httpstat.us/202")
 
 
-    @_recorder.record(file_path="out.toml")
+    @_recorder.record(file_path="out.yaml")
     def test_recorder():
         rsp = requests.get("https://httpstat.us/404")
         rsp = requests.get("https://httpbin.org/status/wrong")
@@ -98,55 +98,49 @@ Following code
 
 will produce next output:
 
-.. code-block:: toml
+.. code-block:: yaml
 
-    [[responses]]
+    responses:
+    - response:
+        auto_calculate_content_length: false
+        body: 404 Not Found
+        content_type: text/plain
+        method: GET
+        status: 404
+        url: https://httpstat.us/404
+    - response:
+        auto_calculate_content_length: false
+        body: Invalid status code
+        content_type: text/plain
+        method: GET
+        status: 400
+        url: https://httpbin.org/status/wrong
+    - response:
+        auto_calculate_content_length: false
+        body: 500 Internal Server Error
+        content_type: text/plain
+        method: GET
+        status: 500
+        url: https://httpstat.us/500
+    - response:
+        auto_calculate_content_length: false
+        body: 202 Accepted
+        content_type: text/plain
+        method: GET
+        status: 202
+        url: https://httpstat.us/202
 
-    [responses.response]
-    method = "GET"
-    url = "https://httpstat.us/404"
-    body = "404 Not Found"
-    status = 404
-    content_type = "text/plain"
-    auto_calculate_content_length = false
-    [[responses]]
-
-    [responses.response]
-    method = "GET"
-    url = "https://httpbin.org/status/wrong"
-    body = "Invalid status code"
-    status = 400
-    content_type = "text/plain"
-    auto_calculate_content_length = false
-    [[responses]]
-
-    [responses.response]
-    method = "GET"
-    url = "https://httpstat.us/500"
-    body = "500 Internal Server Error"
-    status = 500
-    content_type = "text/plain"
-    auto_calculate_content_length = false
-    [[responses]]
-
-    [responses.response]
-    method = "GET"
-    url = "https://httpstat.us/202"
-    body = "202 Accepted"
-    status = 202
-    content_type = "text/plain"
-    auto_calculate_content_length = false
 
 Replay responses (populate registry) from files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can populate your active registry from a ``toml`` file with recorded responses.
+You can populate your active registry from a ``yaml`` file with recorded responses.
 (See `Record Responses to files`_ to understand how to obtain a file).
-To do that you need to execute ``responses._add_from_file(file_path="out.toml")`` within
+To do that you need to execute ``responses._add_from_file(file_path="out.yaml")`` within
 an activated decorator or a context manager.
 
 The following code example registers a ``patch`` response, then all responses present in
-``out.toml`` file and a ``post`` response at the end.
+``out.yaml`` file and a ``post`` response at the end.
 
 .. code-block:: python
 
@@ -156,7 +150,7 @@ The following code example registers a ``patch`` response, then all responses pr
     @responses.activate
     def run():
         responses.patch("http://httpbin.org")
-        responses._add_from_file(file_path="out.toml")
+        responses._add_from_file(file_path="out.yaml")
         responses.post("http://httpbin.org/form")
 
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -25,11 +25,13 @@ from typing import Union
 from typing import overload
 from warnings import warn
 
+import yaml
+
 try:
     import tomli as _toml
 except ImportError:
     # python 3.11
-    import tomllib as _toml  # type: ignore[no-redef]
+    import tomllib as _toml  # type: ignore[no-redef] # noqa: F401
 
 from requests.adapters import HTTPAdapter
 from requests.adapters import MaxRetryError
@@ -783,9 +785,15 @@ class RequestsMock(object):
     post = partialmethod(add, POST)
     put = partialmethod(add, PUT)
 
+    def _parse_response_file(
+        self, file_path: "Union[str, bytes, os.PathLike[Any]]"
+    ) -> "Dict[str, Any]":
+        with open(file_path, "r") as file:
+            data = yaml.safe_load(file)
+        return data
+
     def _add_from_file(self, file_path: "Union[str, bytes, os.PathLike[Any]]") -> None:
-        with open(file_path, "rb") as file:
-            data = _toml.load(file)
+        data = self._parse_response_file(file_path)
 
         for rsp in data["responses"]:
             rsp = rsp["response"]

--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -79,7 +79,7 @@ class Recorder(RequestsMock):
         self._registry = OrderedRegistry()
 
     def record(
-        self, *, file_path: "Union[str, bytes, os.PathLike[Any]]" = "response.toml"
+        self, *, file_path: "Union[str, bytes, os.PathLike[Any]]" = "response.yaml"
     ) -> "Union[Callable[[_F], _F], _F]":
         def deco_record(function: "_F") -> "Callable[..., Any]":
             @wraps(function)

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup_requires = []
 install_requires = [
     "requests>=2.22.0,<3.0",
     "urllib3>=1.25.10",
-    "tomli; python_version < '3.11'",
-    "tomli-w",
+    "pyyaml",
+    "types-PyYAML",
     "typing_extensions; python_version < '3.8'",
 ]
 
@@ -33,6 +33,9 @@ tests_require = [
     "flake8",
     "types-requests",
     "mypy",
+    # for check of different parsers in recorder
+    "tomli; python_version < '3.11'",
+    "tomli-w",
 ]
 
 if "test" in sys.argv:


### PR DESCRIPTION
Added `responses.RequestsMock._parse_response_file` and  `responses._recorder.Recorder.dump_to_file` methods that allow users to override default parser to eg toml, json

Also, added tests that validate that both yaml and toml could be parsed.

Although, we add a test for toml parsing, I do not want to include methods for toml parsing directly to the lib, so, officially we support only YAML, all the rest implementation will rely on users


closes #615