### PR TITLE
fix test compatibility with urllib3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+0.23.2
+------
+
+* Updated dependency to urllib3>=2 and requests>=2.30.0. See #635
+
+
 0.23.1
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ A utility library for mocking out the ``requests`` Python library.
 
 ..  note::
 
-    Responses requires Python 3.7 or newer, and requests >= 2.22.0
+    Responses requires Python 3.7 or newer, and requests >= 2.30.0
 
 
 Table of Contents

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1498,9 +1498,10 @@ def test_auto_calculate_content_length_doesnt_override_existing_value():
             headers={"Content-Length": "2"},
             auto_calculate_content_length=True,
         )
-        resp = requests.get(url)
-        assert_response(resp, "test")
-        assert resp.headers["Content-Length"] == "2"
+        with pytest.raises(ChunkedEncodingError) as excinfo:
+            requests.get(url)
+
+        assert "IncompleteRead(4 bytes read, -2 more expected)" in str(excinfo.value)
 
     run()
     assert_reset()
@@ -2416,7 +2417,7 @@ class TestMaxRetry:
                 total=total,
                 backoff_factor=0.1,
                 status_forcelist=[500],
-                method_whitelist=["GET", "POST", "PATCH"],
+                allowed_methods=["GET", "POST", "PATCH"],
                 raise_on_status=raise_on_status,
             )
         )

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ from setuptools.command.test import test as TestCommand
 setup_requires = []
 
 install_requires = [
-    "requests>=2.22.0,<3.0",
-    "urllib3>=1.25.10",
+    "requests>=2.30.0,<3.0",
+    "urllib3>=2.0.0,<3.0",
     "pyyaml",
     "types-PyYAML",
     "typing_extensions; python_version < '3.8'",


### PR DESCRIPTION
closes #635 
I thought more about the issue #635. Actually, we are back compatible. 

`urllib3` now enforces content length validation. Our lib proposes auto calculation of content length. However, if the user wants to provide a header and the header does not match actual content length, then user gets an error. 
Which is expected from the new `urllib3`