### PR TITLE
move unbound_send outside of the function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,8 @@
 
 * Updated dependency to urllib3>=2 and requests>=2.30.0. See #635
 * Fixed issue when custom adapters were sending only positional args. See #642
+* Expose `unbound_on_send` method in `RequestsMock` class. This method returns new function
+  that is called by `RequestsMock` instead of original `send` method defined by any adapter.
 
 
 0.23.1

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -38,10 +38,8 @@ from responses.registries import FirstMatchRegistry
 
 try:
     from typing_extensions import Literal
-    from typing_extensions import Protocol
 except ImportError:  # pragma: no cover
     from typing import Literal  # type: ignore  # pragma: no cover
-    from typing import Protocol
 
 try:
     from requests.packages.urllib3.response import HTTPResponse
@@ -69,6 +67,7 @@ from urllib.parse import urlunsplit
 if TYPE_CHECKING:  # pragma: no cover
     # import only for linter run
     import os
+    from typing import Protocol
     from unittest.mock import _patch as _mock_patcher
 
     from requests import PreparedRequest

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -220,29 +220,31 @@ def get_wrapped(
     return wrapper
 
 
-def unbound_on_send(
-    adapter: "HTTPAdapter",
-    request: "PreparedRequest",
-    *args: Any,
-    request_mock=None,
-    **kwargs: Any,
-) -> "models.Response":
-    if args:
-        # that probably means that the request was sent from the custom adapter
-        # It is fully legit to send positional args from adapter, although,
-        # `requests` implementation does it always with kwargs
-        # See for more info: https://github.com/getsentry/responses/issues/642
-        try:
-            kwargs["stream"] = args[0]
-            kwargs["timeout"] = args[1]
-            kwargs["verify"] = args[2]
-            kwargs["cert"] = args[3]
-            kwargs["proxies"] = args[4]
-        except IndexError:
-            # not all kwargs are required
-            pass
+def unbound_on_send(request_mock):
+    def send(
+        adapter: "HTTPAdapter",
+        request: "PreparedRequest",
+        *args: Any,
+        **kwargs: Any,
+    ) -> "models.Response":
+        if args:
+            # that probably means that the request was sent from the custom adapter
+            # It is fully legit to send positional args from adapter, although,
+            # `requests` implementation does it always with kwargs
+            # See for more info: https://github.com/getsentry/responses/issues/642
+            try:
+                kwargs["stream"] = args[0]
+                kwargs["timeout"] = args[1]
+                kwargs["verify"] = args[2]
+                kwargs["cert"] = args[3]
+                kwargs["proxies"] = args[4]
+            except IndexError:
+                # not all kwargs are required
+                pass
 
-    return request_mock._on_request(adapter, request, **kwargs)
+        return request_mock._on_request(adapter, request, **kwargs)
+
+    return send
 
 
 class CallList(Sequence[Any], Sized):
@@ -1124,7 +1126,7 @@ class RequestsMock(object):
             return
 
         self._patcher = std_mock.patch(
-            target=self.target, new=partialmethod(unbound_on_send, request_mock=self)
+            target=self.target, new=unbound_on_send(request_mock=self)
         )
         self._patcher.start()
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -17,6 +17,7 @@ from typing import Iterator
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import Protocol
 from typing import Sequence
 from typing import Sized
 from typing import Tuple
@@ -69,9 +70,6 @@ if TYPE_CHECKING:  # pragma: no cover
     import os
     from unittest.mock import _patch as _mock_patcher
 
-    from mypy_extensions import Arg
-    from mypy_extensions import KwArg
-    from mypy_extensions import VarArg
     from requests import PreparedRequest
     from requests import models
     from urllib3 import Retry as _Retry
@@ -83,6 +81,14 @@ _HeaderSet = Optional[Union[Mapping[str, str], List[Tuple[str, str]]]]
 _MatcherIterable = Iterable[Callable[..., Tuple[bool, str]]]
 _HTTPMethodOrResponse = Optional[Union[str, "BaseResponse"]]
 _URLPatternType = Union["Pattern[str]", str]
+
+
+class UnboundSendProtocol(Protocol):
+    def __call__(
+        self, adapter: HTTPAdapter, request: PreparedRequest, *args: Any, **kwargs: Any
+    ) -> models.Response:
+        ...
+
 
 Call = namedtuple("Call", ["request", "response"])
 _real_send = HTTPAdapter.send
@@ -1094,17 +1100,7 @@ class RequestsMock(object):
                 return response
         return response
 
-    def unbound_on_send(
-        self,
-    ) -> """Callable[  # noqa: F821
-        [
-            Arg(HTTPAdapter, "adapter"),
-            Arg(PreparedRequest, "request"),
-            VarArg(Any),
-            KwArg(Any),
-        ],
-        models.Response,
-    ]""":
+    def unbound_on_send(self) -> UnboundSendProtocol:
         def send(
             adapter: "HTTPAdapter",
             request: "PreparedRequest",

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -220,6 +220,31 @@ def get_wrapped(
     return wrapper
 
 
+def unbound_on_send(
+    adapter: "HTTPAdapter",
+    request: "PreparedRequest",
+    *args: Any,
+    request_mock=None,
+    **kwargs: Any,
+) -> "models.Response":
+    if args:
+        # that probably means that the request was sent from the custom adapter
+        # It is fully legit to send positional args from adapter, although,
+        # `requests` implementation does it always with kwargs
+        # See for more info: https://github.com/getsentry/responses/issues/642
+        try:
+            kwargs["stream"] = args[0]
+            kwargs["timeout"] = args[1]
+            kwargs["verify"] = args[2]
+            kwargs["cert"] = args[3]
+            kwargs["proxies"] = args[4]
+        except IndexError:
+            # not all kwargs are required
+            pass
+
+    return request_mock._on_request(adapter, request, **kwargs)
+
+
 class CallList(Sequence[Any], Sized):
     def __init__(self) -> None:
         self._calls: List[Call] = []
@@ -1098,30 +1123,9 @@ class RequestsMock(object):
             # another decorated function
             return
 
-        def unbound_on_send(
-            adapter: "HTTPAdapter",
-            request: "PreparedRequest",
-            *args: Any,
-            **kwargs: Any,
-        ) -> "models.Response":
-            if args:
-                # that probably means that the request was sent from the custom adapter
-                # It is fully legit to send positional args from adapter, although,
-                # `requests` implementation does it always with kwargs
-                # See for more info: https://github.com/getsentry/responses/issues/642
-                try:
-                    kwargs["stream"] = args[0]
-                    kwargs["timeout"] = args[1]
-                    kwargs["verify"] = args[2]
-                    kwargs["cert"] = args[3]
-                    kwargs["proxies"] = args[4]
-                except IndexError:
-                    # not all kwargs are required
-                    pass
-
-            return self._on_request(adapter, request, **kwargs)
-
-        self._patcher = std_mock.patch(target=self.target, new=unbound_on_send)
+        self._patcher = std_mock.patch(
+            target=self.target, new=partialmethod(unbound_on_send, request_mock=self)
+        )
         self._patcher.start()
 
     def stop(self, allow_assert: bool = True) -> None:

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -17,7 +17,6 @@ from typing import Iterator
 from typing import List
 from typing import Mapping
 from typing import Optional
-from typing import Protocol
 from typing import Sequence
 from typing import Sized
 from typing import Tuple
@@ -39,8 +38,10 @@ from responses.registries import FirstMatchRegistry
 
 try:
     from typing_extensions import Literal
+    from typing_extensions import Protocol
 except ImportError:  # pragma: no cover
     from typing import Literal  # type: ignore  # pragma: no cover
+    from typing import Protocol
 
 try:
     from requests.packages.urllib3.response import HTTPResponse
@@ -74,6 +75,17 @@ if TYPE_CHECKING:  # pragma: no cover
     from requests import models
     from urllib3 import Retry as _Retry
 
+    class UnboundSend(Protocol):
+        def __call__(
+            self,
+            adapter: HTTPAdapter,
+            request: PreparedRequest,
+            *args: Any,
+            **kwargs: Any,
+        ) -> models.Response:
+            ...
+
+
 # Block of type annotations
 _Body = Union[str, BaseException, "Response", BufferedReader, bytes, None]
 _F = Callable[..., Any]
@@ -81,13 +93,6 @@ _HeaderSet = Optional[Union[Mapping[str, str], List[Tuple[str, str]]]]
 _MatcherIterable = Iterable[Callable[..., Tuple[bool, str]]]
 _HTTPMethodOrResponse = Optional[Union[str, "BaseResponse"]]
 _URLPatternType = Union["Pattern[str]", str]
-
-
-class UnboundSendProtocol(Protocol):
-    def __call__(
-        self, adapter: HTTPAdapter, request: PreparedRequest, *args: Any, **kwargs: Any
-    ) -> models.Response:
-        ...
 
 
 Call = namedtuple("Call", ["request", "response"])
@@ -1100,7 +1105,7 @@ class RequestsMock(object):
                 return response
         return response
 
-    def unbound_on_send(self) -> UnboundSendProtocol:
+    def unbound_on_send(self) -> "UnboundSend":
         def send(
             adapter: "HTTPAdapter",
             request: "PreparedRequest",


### PR DESCRIPTION
Moving `unbound_on_send` outside of the function will allow users to override the method if they will need to without a need to rewrite the entire `start` method