### PR TITLE
python 3.7 notice

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.23.2
 ------
 
+> This release is the last to support Python 3.7
+
 * Updated dependency to urllib3>=2 and requests>=2.30.0. See #635
 * Fixed issue when custom adapters were sending only positional args. See #642
 


### PR DESCRIPTION
add notice that python 3.7 will not be supported in the future versions of the lib