### PR TITLE
chore: UserWarning if body provided for unsupported status

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -567,6 +567,17 @@ class Response(BaseResponse):
                 "stream argument is deprecated. Use stream parameter in request directly",
                 DeprecationWarning,
             )
+        # Check for responses that shouldn't include a body
+        if body:
+            if status in (204, 304) or 100 <= status < 200:
+                warn_msg = (
+                    f"Providing a body/json value with status == {status} may cause a "
+                    f"`requests.exceptions.ChunkedEncodingError: ('Connection broken: "
+                    f"IncompleteRead({len(body)} bytes read, -{len(body)} more "
+                    f"expected)', IncompleteRead({len(body)} bytes read, -{len(body)} "
+                    f"more expected))` error."
+                )
+                warn(warn_msg, category=UserWarning, stacklevel=3)
 
         self.stream: Optional[bool] = stream
         self.content_type: str = content_type  # type: ignore[assignment]

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -2574,3 +2574,39 @@ def test_request_object_attached_to_exception():
 
     run()
     assert_reset()
+
+
+def test_status_204_unexpected_body_warning():
+    @responses.activate
+    def run():
+        with pytest.warns(
+            UserWarning, match="Providing a body/json value with status == 204"
+        ):
+            responses.delete(
+                "http://example.com/1",
+                status=204,
+                json={"message": "204 No Content"},
+            )
+        with pytest.raises(requests.exceptions.ChunkedEncodingError):
+            resp = requests.delete("http://example.com/1")
+
+    run()
+    assert_reset()
+
+
+def test_status_101_unexpected_body_warning():
+    @responses.activate
+    def run():
+        with pytest.warns(
+            UserWarning, match="Providing a body/json value with status == 101"
+        ):
+            responses.get(
+                "http://example.com/1",
+                status=101,
+                json={"message": "101"},
+            )
+        with pytest.raises(requests.exceptions.ChunkedEncodingError):
+            resp = requests.get("http://example.com/1")
+
+    run()
+    assert_reset()


### PR DESCRIPTION
After the change to urllib3 v2, certain status codes are not expected to have any content returned in the response. If they do have content then requests (via urllib3) will cause an error like:
  `requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(18 bytes read, -18 more expected)', IncompleteRead(18 bytes read, -18 more expected))`

This can be confusing to users using responses who had set a body in previous versions of urllib3 without any issues. Emit a `UserWarning` to help users remedy the issue.