### PR TITLE
[#651] regex compatability for headers matching

### DIFF
--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -1,4 +1,5 @@
 import json as json_module
+import re
 from json.decoder import JSONDecodeError
 from typing import Any
 from typing import Callable
@@ -402,6 +403,19 @@ def header_matcher(
     :return: (func) matcher
     """
 
+    def __compare_with_regex(request_headers: Union[Dict[Any, Any], Any]) -> bool:
+        checked_request_headers = {k: 1 for k in request_headers.keys()}
+        for k, v in headers.items():
+            if request_headers.get(k) is not None:
+                checked_request_headers[k] = 0
+                if isinstance(v, re.Pattern):
+                    if re.match(v, request_headers[k]) is None:
+                        return False
+                else:
+                    if not v == request_headers[k]:
+                        return False
+        return True if not strict_match else sum(checked_request_headers.values()) == 0
+
     def match(request: PreparedRequest) -> Tuple[bool, str]:
         request_headers: Union[Dict[Any, Any], Any] = request.headers or {}
 
@@ -409,7 +423,7 @@ def header_matcher(
             # filter down to just the headers specified in the matcher
             request_headers = {k: v for k, v in request_headers.items() if k in headers}
 
-        valid = sorted(headers.items()) == sorted(request_headers.items())
+        valid = __compare_with_regex(request_headers)
 
         if not valid:
             return False, "Headers do not match: {} doesn't match {}".format(


### PR DESCRIPTION
Attempt at #651.

- Changes in `header_matcher` function.
- Instead of using simple list equality, it now checks for either regex or simple string check.
- Added test `test_request_matches_headers_regex`