### PR TITLE
[#651] regex compatability for headers matching

### DIFF
--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -1,4 +1,5 @@
 import json as json_module
+import re
 from json.decoder import JSONDecodeError
 from typing import Any
 from typing import Callable
@@ -402,6 +403,19 @@ def header_matcher(
     :return: (func) matcher
     """
 
+    def __compare_with_regex(request_headers: Union[Dict[Any, Any], Any]) -> bool:
+        checked_request_headers = {k: 1 for k in request_headers.keys()}
+        for k, v in headers.items():
+            if request_headers.get(k) is not None:
+                checked_request_headers[k] = 0
+                if isinstance(v, re.Pattern):
+                    if re.match(v, request_headers[k]) is None:
+                        return False
+                else:
+                    if not v == request_headers[k]:
+                        return False
+        return True if not strict_match else sum(checked_request_headers.values()) == 0
+
     def match(request: PreparedRequest) -> Tuple[bool, str]:
         request_headers: Union[Dict[Any, Any], Any] = request.headers or {}
 
@@ -409,7 +423,7 @@ def header_matcher(
             # filter down to just the headers specified in the matcher
             request_headers = {k: v for k, v in request_headers.items() if k in headers}
 
-        valid = sorted(headers.items()) == sorted(request_headers.items())
+        valid = __compare_with_regex(request_headers)
 
         if not valid:
             return False, "Headers do not match: {} doesn't match {}".format(

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -818,7 +818,51 @@ def test_request_matches_headers_regex():
     assert_reset()
 
 
-def test_request_matches_headers_regex_strict_match():
+def test_request_matches_headers_regex_strict_match_regex_failed():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            body="success",
+            match=[
+                matchers.header_matcher(
+                    {
+                        "Accept": "text/plain",
+                        "Message-Signature": re.compile(r'signature="\S+",created=\d+'),
+                    },
+                    strict_match=True,
+                )
+            ],
+        )
+
+        session = requests.Session()
+        # requests will add some extra headers of its own, so we have to use prepared requests
+        prepped = session.prepare_request(
+            requests.Request(
+                method="GET",
+                url=url,
+            )
+        )
+        prepped.headers.clear()
+        prepped.headers["Accept"] = "text/plain"
+        prepped.headers["Message-Signature"] = 'signature="123",created=abc'
+        with pytest.raises(ConnectionError) as excinfo:
+            session.send(prepped)
+        msg = str(excinfo.value)
+        assert (
+            "Headers do not match: {Accept: text/plain, Message-Signature: "
+            'signature="123",created=abc} '
+            "doesn't match {Accept: text/plain, Message-Signature: "
+            "re.compile('signature=\"\\\\S+\",created=\\\\d+')}"
+        ) in msg
+
+    run()
+    assert_reset()
+
+
+def test_request_matches_headers_regex_strict_match_mismatched_field():
     @responses.activate
     def run():
         url = "http://example.com/"
@@ -839,8 +883,6 @@ def test_request_matches_headers_regex_strict_match():
 
         # requests will add some extra headers of its own, so we have to use prepared requests
         session = requests.Session()
-
-        # make sure we send *just* the header we're expectin
         prepped = session.prepare_request(
             requests.Request(
                 method="GET",
@@ -849,11 +891,42 @@ def test_request_matches_headers_regex_strict_match():
         )
         prepped.headers.clear()
         prepped.headers["Accept"] = "text/plain"
-        prepped.headers["Message-Signature"] = 'signature="abc",created=1243'
+        prepped.headers["Accept-Charset"] = "utf-8"
+        # "Accept-Charset" header will fail to match to "Message-Signature"
+        with pytest.raises(ConnectionError) as excinfo:
+            session.send(prepped)
+        msg = str(excinfo.value)
+        assert (
+            "Headers do not match: {Accept: text/plain, Accept-Charset: utf-8} "
+            "doesn't match {Accept: text/plain, Message-Signature: "
+            "re.compile('signature=\"\\\\S+\",created=\\\\d+')}"
+        ) in msg
 
-        resp = session.send(prepped)
-        assert_response(resp, body="success", content_type="text/plain")
+    run()
+    assert_reset()
 
+
+def test_request_matches_headers_regex_strict_match_mismatched_number():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            body="success",
+            match=[
+                matchers.header_matcher(
+                    {
+                        "Accept": "text/plain",
+                        "Message-Signature": re.compile(r'signature="\S+",created=\d+'),
+                    },
+                    strict_match=True,
+                )
+            ],
+        )
+
+        # requests will add some extra headers of its own, so we have to use prepared requests
+        session = requests.Session()
         # include the "Accept-Charset" header, which will fail to match
         prepped = session.prepare_request(
             requests.Request(
@@ -865,10 +938,8 @@ def test_request_matches_headers_regex_strict_match():
         prepped.headers["Accept"] = "text/plain"
         prepped.headers["Accept-Charset"] = "utf-8"
         prepped.headers["Message-Signature"] = 'signature="abc",created=1243'
-
         with pytest.raises(ConnectionError) as excinfo:
             session.send(prepped)
-
         msg = str(excinfo.value)
         assert (
             "Headers do not match: {Accept: text/plain, Accept-Charset: utf-8, "
@@ -877,6 +948,43 @@ def test_request_matches_headers_regex_strict_match():
             "doesn't match {Accept: text/plain, Message-Signature: "
             "re.compile('signature=\"\\\\S+\",created=\\\\d+')}"
         ) in msg
+
+    run()
+    assert_reset()
+
+
+def test_request_matches_headers_regex_strict_match_positive():
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            body="success",
+            match=[
+                matchers.header_matcher(
+                    {
+                        "Accept": "text/plain",
+                        "Message-Signature": re.compile(r'signature="\S+",created=\d+'),
+                    },
+                    strict_match=True,
+                )
+            ],
+        )
+
+        # requests will add some extra headers of its own, so we have to use prepared requests
+        session = requests.Session()
+        prepped = session.prepare_request(
+            requests.Request(
+                method="GET",
+                url=url,
+            )
+        )
+        prepped.headers.clear()
+        prepped.headers["Accept"] = "text/plain"
+        prepped.headers["Message-Signature"] = 'signature="abc",created=1243'
+        resp = session.send(prepped)
+        assert_response(resp, body="success", content_type="text/plain")
 
     run()
     assert_reset()

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -786,7 +786,9 @@ def test_matchers_create_key_val_str():
 
 
 class TestHeaderWithRegex:
-    url = "http://example.com/"
+    @property
+    def url(self):
+        return "http://example.com/"
 
     def _register(self):
         responses.add(


### PR DESCRIPTION
Attempt at #651.

- Changes in `header_matcher` function.
- Instead of using simple list equality, it now checks for either regex or simple string check.
- Added tests `test_request_matches_headers_regex`, `test_request_matches_headers_regex_strict_match`