### PR TITLE
Calls info in BaseResponse

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.24.0
 ------
 
+* Added `BaseResponse.calls` to access calls data of a separate mocked request. See #664
 * Added support for re.Pattern based header matching.
 * Added support for gzipped response bodies to `json_params_matcher`.
 * Moved types-pyyaml dependency to `tests_requires`

--- a/README.rst
+++ b/README.rst
@@ -1113,7 +1113,7 @@ applications.
             for future in concurrent.futures.as_completed(future_to_uid):
                 uid = future_to_uid[future]
                 response = future.result()
-                print("%s updated with %d status code" % (uid, response.status_code))
+                print(f"{uid} updated with {response.status_code} status code")
 
         assert len(responses.calls) == 3  # total calls count
 

--- a/README.rst
+++ b/README.rst
@@ -1094,8 +1094,8 @@ in the global list of ``Registry``.
     @responses.activate
     def test_assert_calls_on_resp():
         rsp = responses.add(responses.GET, "http://www.example.com")
-        rsp2 = responses.add(
-            responses.PUT, "http://foo.bar/42/", json={"id": 42, "name": "Bazz"}
+        rsp2 = responses.put(
+            "http://foo.bar/42/", json={"id": 42, "name": "Bazz"}
         )
 
         requests.get("http://www.example.com")

--- a/README.rst
+++ b/README.rst
@@ -1136,16 +1136,28 @@ applications.
 
         assert rsp0123.call_count == 1
         assert rsp0123.calls[0] in responses.calls
-        assert json.loads(rsp0123.calls[0].request.body) == {"client": True, "admin": False, "disabled": False}
+        assert json.loads(rsp0123.calls[0].request.body) == {
+            "client": True,
+            "admin": False,
+            "disabled": False,
+        }
 
         assert rsp1234.call_count == 1
         assert rsp1234.calls[0] in responses.calls
-        assert json.loads(rsp1234.calls[0].request.body) == {"client": False, "admin": True, "disabled": False}
+        assert json.loads(rsp1234.calls[0].request.body) == {
+            "client": False,
+            "admin": True,
+            "disabled": False,
+        }
         assert rsp1234.calls[0].response.json() == {"OK": False, "uid": "1234"}
 
         assert rsp2345.call_count == 1
         assert rsp2345.calls[0] in responses.calls
-        assert json.loads(rsp2345.calls[0].request.body) == {"client": False, "admin": False, "disabled": True}
+        assert json.loads(rsp2345.calls[0].request.body) == {
+            "client": False,
+            "admin": False,
+            "disabled": True,
+        }
 
 
 Multiple Responses

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -394,7 +394,7 @@ class BaseResponse(object):
             )
 
         self.match: "_MatcherIterable" = match
-        self.call_count: int = 0
+        self._calls: CallList = CallList()
         self.passthrough = passthrough
 
     def __eq__(self, other: Any) -> bool:
@@ -502,6 +502,14 @@ class BaseResponse(object):
             return False, reason
 
         return True, ""
+
+    @property
+    def call_count(self) -> int:
+        return len(self._calls)
+
+    @property
+    def calls(self) -> CallList:
+        return self._calls
 
 
 def _form_response(
@@ -1064,13 +1072,13 @@ class RequestsMock(object):
                     request, match.get_response(request)
                 )
             except BaseException as response:
-                match.call_count += 1
+                match.calls.add(request, response)
                 self._calls.add(request, response)
                 raise
 
         if resp_callback:
             response = resp_callback(response)  # type: ignore[misc]
-        match.call_count += 1
+        match.calls.add(request, response)
         self._calls.add(request, response)  # type: ignore[misc]
 
         retries = retries or adapter.max_retries

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1073,16 +1073,16 @@ class RequestsMock:
                     request, match.get_response(request)
                 )
             except BaseException as response:
-                next_index = len(self._calls)
-                self._calls.add(request, response)
-                match.calls.add_call(self._calls[next_index])
+                call = Call(request, response)
+                self._calls.add_call(call)
+                match.calls.add_call(call)
                 raise
 
         if resp_callback:
             response = resp_callback(response)  # type: ignore[misc]
-        next_index = len(self._calls)
-        self._calls.add(request, response)  # type: ignore[misc]
-        match.calls.add_call(self._calls[next_index])
+        call = Call(request, response)
+        self._calls.add_call(call)
+        match.calls.add_call(call)
 
         retries = retries or adapter.max_retries
         # first validate that current request is eligible to be retried.

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -42,17 +42,23 @@ except ImportError:  # pragma: no cover
     from typing import Literal  # type: ignore  # pragma: no cover
 
 try:
-    from requests.packages.urllib3.response import HTTPResponse
+    from requests.packages.urllib3.response import (
+        HTTPResponse,  # type: ignore[import-untyped]
+    )
 except ImportError:  # pragma: no cover
     from urllib3.response import HTTPResponse  # pragma: no cover
 
 try:
-    from requests.packages.urllib3.connection import HTTPHeaderDict
+    from requests.packages.urllib3.connection import (
+        HTTPHeaderDict,  # type: ignore[import-untyped]
+    )
 except ImportError:  # pragma: no cover
     from urllib3.response import HTTPHeaderDict
 
 try:
-    from requests.packages.urllib3.util.url import parse_url
+    from requests.packages.urllib3.util.url import (
+        parse_url,  # type: ignore[import-untyped]
+    )
 except ImportError:  # pragma: no cover
     from urllib3.util.url import parse_url  # pragma: no cover
 
@@ -252,11 +258,11 @@ class CallList(Sequence[Any], Sized):
         return len(self._calls)
 
     @overload
-    def __getitem__(self, idx: int) -> Call:
+    def __getitem__(self, idx: int) -> Call:  # type: ignore[misc]
         """Overload when get a single item."""
 
     @overload
-    def __getitem__(self, idx: slice) -> List[Call]:
+    def __getitem__(self, idx: slice) -> List[Call]:  # type: ignore[misc]
         """Overload when a slice is requested."""
 
     def __getitem__(self, idx: Union[int, slice]) -> Union[Call, List[Call]]:
@@ -978,7 +984,7 @@ class RequestsMock:
         """Overload for scenario when 'responses.activate' is used."""
 
     @overload
-    def activate(
+    def activate(  # type: ignore[misc]
         self,
         *,
         registry: Type[Any] = ...,

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -255,6 +255,9 @@ class CallList(Sequence[Any], Sized):
     def add(self, request: "PreparedRequest", response: _Body) -> None:
         self._calls.append(Call(request, response))
 
+    def add_call(self, call: Call) -> None:
+        self._calls.append(call)
+
     def reset(self) -> None:
         self._calls = []
 
@@ -1072,14 +1075,16 @@ class RequestsMock(object):
                     request, match.get_response(request)
                 )
             except BaseException as response:
-                match.calls.add(request, response)
+                next_index = len(self._calls)
                 self._calls.add(request, response)
+                match.calls.add_call(self._calls[next_index])
                 raise
 
         if resp_callback:
             response = resp_callback(response)  # type: ignore[misc]
-        match.calls.add(request, response)
+        next_index = len(self._calls)
         self._calls.add(request, response)  # type: ignore[misc]
+        match.calls.add_call(self._calls[next_index])
 
         retries = retries or adapter.max_retries
         # first validate that current request is eligible to be retried.

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1103,7 +1103,7 @@ class RequestsMock:
 
         if resp_callback:
             response = resp_callback(response)  # type: ignore[misc]
-        call = Call(request, response)
+        call = Call(request, response)  # type: ignore[misc]
         self._calls.add_call(call)
         match.calls.add_call(call)
 

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qsl
 from urllib.parse import urlparse
 
 from requests import PreparedRequest
-from requests.packages.urllib3.util.url import parse_url
+from requests.packages.urllib3.util.url import parse_url  # type: ignore[import-untyped]
 
 
 def _create_key_val_str(input_dict: Union[Dict[Any, Any], Any]) -> str:

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 import os
 import re
 import warnings
@@ -2036,83 +2035,31 @@ def test_call_count_without_matcher():
     assert_reset()
 
 
-def test_response_and_requests_mock_calls_are_equal():
-    @responses.activate
-    def run():
-        rsp = responses.add(responses.GET, "http://www.example.com")
-        rsp2 = responses.add(responses.GET, "http://www.example.com/1")
-
-        requests.get("http://www.example.com")
-        requests.get("http://www.example.com/1")
-
-        assert len(responses.calls) == 2
-        assert rsp.call_count == 1
-        assert rsp.calls[0] is responses.calls[0]
-        assert rsp2.call_count == 1
-        assert rsp2.calls[0] is responses.calls[1]
-
-    run()
-    assert_reset()
-
-
-def test_response_call_request():
+def test_response_calls_and_registry_calls_are_equal():
     @responses.activate
     def run():
         rsp1 = responses.add(responses.GET, "http://www.example.com")
-        rsp2 = responses.add(
-            responses.PUT, "http://www.foo.bar/42/", json={"id": 42, "name": "Bazz"}
-        )
-        request_payload = {"name": "Bazz"}
+        rsp2 = responses.add(responses.GET, "http://www.example.com/1")
+        rsp3 = responses.add(
+            responses.GET, "http://www.example.com/2"
+        )  # won't be requested
 
         requests.get("http://www.example.com")
-        requests.get("http://www.example.com?hello=world")
-        requests.put(
-            "http://www.foo.bar/42/",
-            json=request_payload,
-        )
+        requests.get("http://www.example.com/1")
+        requests.get("http://www.example.com")
 
+        assert len(responses.calls) == len(rsp1.calls) + len(rsp2.calls) + len(
+            rsp3.calls
+        )
         assert rsp1.call_count == 2
-        rsp1_request1 = rsp1.calls[0].request
-        assert rsp1_request1.url == "http://www.example.com/"
-        assert rsp1_request1.method == "GET"
-        rsp1_request2 = rsp1.calls[1].request
-        assert rsp1_request2.url == "http://www.example.com/?hello=world"
-        assert rsp1_request2.method == "GET"
+        assert len(rsp1.calls) == 2
+        assert rsp1.calls[0] is responses.calls[0]
+        assert rsp1.calls[1] is responses.calls[2]
         assert rsp2.call_count == 1
-        rsp2_request1 = rsp2.calls[0].request
-        assert rsp2_request1.url == "http://www.foo.bar/42/"
-        assert rsp2_request1.method == "PUT"
-        assert json.loads(rsp2_request1.body) == request_payload
-
-    run()
-    assert_reset()
-
-
-def test_response_call_response():
-    @responses.activate
-    def run():
-        rsp1 = responses.add(responses.GET, "http://www.example.com", body=b"test")
-        rsp2 = responses.add(
-            responses.POST,
-            "http://www.foo.bar/42/",
-            json={"id": 42, "name": "Bazz"},
-            status=201,
-        )
-
-        requests.get("http://www.example.com")
-        requests.post(
-            "http://www.foo.bar/42/",
-            json={"name": "Bazz"},
-        )
-
-        assert rsp1.call_count == 1
-        rsp1_response = rsp1.calls[0].response
-        assert rsp1_response.content == b"test"
-        assert rsp1_response.status_code == 200
-        assert rsp2.call_count == 1
-        rsp2_response = rsp2.calls[0].response
-        assert rsp2_response.json() == {"id": 42, "name": "Bazz"}
-        assert rsp2_response.status_code == 201
+        assert len(rsp2.calls) == 1
+        assert rsp2.calls[0] is responses.calls[1]
+        assert rsp3.call_count == 0
+        assert len(rsp3.calls) == 0
 
     run()
     assert_reset()

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -2058,31 +2058,31 @@ def test_response_and_requests_mock_calls_are_equal():
 def test_response_call_request():
     @responses.activate
     def run():
-        rsp = responses.add(responses.GET, "http://www.example.com")
+        rsp1 = responses.add(responses.GET, "http://www.example.com")
         rsp2 = responses.add(
             responses.PUT, "http://www.foo.bar/42/", json={"id": 42, "name": "Bazz"}
         )
+        request_payload = {"name": "Bazz"}
 
         requests.get("http://www.example.com")
         requests.get("http://www.example.com?hello=world")
         requests.put(
             "http://www.foo.bar/42/",
-            json={"name": "Bazz"},
+            json=request_payload,
         )
 
-        assert rsp.call_count == 2
-        request = rsp.calls[0].request
-        assert request.url == "http://www.example.com/"
-        assert request.method == "GET"
-        request = rsp.calls[1].request
-        assert request.url == "http://www.example.com/?hello=world"
-        assert request.method == "GET"
+        assert rsp1.call_count == 2
+        rsp1_request1 = rsp1.calls[0].request
+        assert rsp1_request1.url == "http://www.example.com/"
+        assert rsp1_request1.method == "GET"
+        rsp1_request2 = rsp1.calls[1].request
+        assert rsp1_request2.url == "http://www.example.com/?hello=world"
+        assert rsp1_request2.method == "GET"
         assert rsp2.call_count == 1
-        request = rsp2.calls[0].request
-        assert request.url == "http://www.foo.bar/42/"
-        assert request.method == "PUT"
-        request_payload = json.loads(request.body)
-        assert request_payload == {"name": "Bazz"}
+        rsp2_request1 = rsp2.calls[0].request
+        assert rsp2_request1.url == "http://www.foo.bar/42/"
+        assert rsp2_request1.method == "PUT"
+        assert json.loads(rsp2_request1.body) == request_payload
 
     run()
     assert_reset()
@@ -2091,7 +2091,7 @@ def test_response_call_request():
 def test_response_call_response():
     @responses.activate
     def run():
-        rsp = responses.add(responses.GET, "http://www.example.com", body=b"test")
+        rsp1 = responses.add(responses.GET, "http://www.example.com", body=b"test")
         rsp2 = responses.add(
             responses.POST,
             "http://www.foo.bar/42/",
@@ -2105,14 +2105,14 @@ def test_response_call_response():
             json={"name": "Bazz"},
         )
 
-        assert rsp.call_count == 1
-        response = rsp.calls[0].response
-        assert response.content == b"test"
-        assert response.status_code == 200
+        assert rsp1.call_count == 1
+        rsp1_response = rsp1.calls[0].response
+        assert rsp1_response.content == b"test"
+        assert rsp1_response.status_code == 200
         assert rsp2.call_count == 1
-        response = rsp2.calls[0].response
-        assert response.json() == {"id": 42, "name": "Bazz"}
-        assert response.status_code == 201
+        rsp2_response = rsp2.calls[0].response
+        assert rsp2_response.json() == {"id": 42, "name": "Bazz"}
+        assert rsp2_response.status_code == 201
 
     run()
     assert_reset()


### PR DESCRIPTION
Sometimes it is more convenient to get information about the calls made directly from the mockend request, instead of calculating the order of your calls in the global list (`responses.calls[n]`).

What do you think of such a possibility?