### PR TITLE
Support gzipped request.body in json_params_matcher

### DIFF
--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -126,11 +126,11 @@ def json_params_matcher(
         request_body = request.body
         json_params = (params or {}) if not isinstance(params, list) else params
         try:
-            if isinstance(request_body, bytes):
+            if isinstance(request.body, bytes):
                 try:
-                    request_body = request_body.decode("utf-8")
+                    request_body = request.body.decode("utf-8")
                 except UnicodeDecodeError:
-                    request_body = gzip.decompress(request_body).decode("utf-8")
+                    request_body = gzip.decompress(request.body).decode("utf-8")
             json_body = json_module.loads(request_body) if request_body else {}
 
             if (

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -1,3 +1,4 @@
+import gzip
 import json as json_module
 import re
 from json.decoder import JSONDecodeError
@@ -126,7 +127,10 @@ def json_params_matcher(
         json_params = (params or {}) if not isinstance(params, list) else params
         try:
             if isinstance(request_body, bytes):
-                request_body = request_body.decode("utf-8")
+                try:
+                    request_body = request_body.decode("utf-8")
+                except UnicodeDecodeError:
+                    request_body = gzip.decompress(request_body).decode("utf-8")
             json_body = json_module.loads(request_body) if request_body else {}
 
             if (

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -1,3 +1,4 @@
+import gzip
 import re
 from unittest.mock import Mock
 
@@ -153,6 +154,14 @@ def test_json_params_matcher_json_list():
 def test_json_params_matcher_json_list_empty():
     json_a = []
     json_b = "[]"
+    mock_request = Mock(body=json_b)
+    result = matchers.json_params_matcher(json_a)(mock_request)
+    assert result == (True, "")
+
+
+def test_json_params_matcher_body_is_gzipped():
+    json_a = {"foo": 42, "bar": None}
+    json_b = gzip.compress('{"foo": 42, "bar": null}'.encode("utf-8"))
     mock_request = Mock(body=json_b)
     result = matchers.json_params_matcher(json_a)(mock_request)
     assert result == (True, "")


### PR DESCRIPTION
I just discovered `matchers` (absolute lifesaver in concurrent tests), but I currently need to disable gzip for the tests since it isn't supported ootb.

Ltmk if there are additional changed/updates/changelog entries etc. you want me to create 😄 