### PR TITLE
fix mypy issue

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1048,7 +1048,7 @@ class RequestsMock:
                     error_msg += f"- {p}\n"
 
             response = ConnectionError(error_msg)
-            response.request = request
+            response.request = request  # type: ignore[assignment]
 
             self._calls.add(request, response)
             raise response


### PR DESCRIPTION
Currently `mypy` is raising an error on `master` branch

```
responses/__init__.py:1051:32: error: Incompatible types in assignment (expression has type "PreparedRequest", variable has type "Request | None")  [assignment]
```

I do not know why mypy thinks that it could be None