### PR TITLE
Revert "fix mypy issue"

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1048,7 +1048,7 @@ class RequestsMock:
                     error_msg += f"- {p}\n"
 
             response = ConnectionError(error_msg)
-            response.request = request  # type: ignore[assignment]
+            response.request = request
 
             self._calls.add(request, response)
             raise response


### PR DESCRIPTION
Reverts getsentry/responses#674

I do not know why, but now it started to work back and CI fails on [master](https://github.com/getsentry/responses/actions/runs/6301576006/job/17106907833) (facepalm)