### PR TITLE
fix coverage on master

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1048,7 +1048,7 @@ class RequestsMock:
                     error_msg += f"- {p}\n"
 
             response = ConnectionError(error_msg)
-            response.request = request  # type: ignore[assignment]
+            response.request = request
 
             self._calls.add(request, response)
             raise response

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
 try:
     from requests.packages.urllib3.connection import HTTPHeaderDict
 except ImportError:  # pragma: no cover
-    from urllib3.response import HTTPHeaderDict  # type: ignore[attr-defined]
+    from urllib3.response import HTTPHeaderDict  # pragma: no cover
 try:
     from requests.packages.urllib3.util.url import parse_url
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
change the order of dependencies installation to ensure that `urllib3` is not overwritten. Otherwise we have an issue that we do not test `urllib3<2`


@markstory 
I do not feel super comfortable with the order of installation of packages. In theory we can end up that we have artificial packages meaning that we override those packages that are specified in `setup.py` and we test not the real package. 

from CI I see the following error
```
types-requests 2.31.0.7 requires urllib3>=2
```

for me it feels that we still have to drop urllib3<2 since the upstream is moving towards it. 