### PR TITLE
fix CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ${{ matrix.requests-version }} ${{ matrix.urllib3-version }}
         make install-deps
+        pip install ${{ matrix.requests-version }} ${{ matrix.urllib3-version }}
 
     - name: Run Pytest
       run: |


### PR DESCRIPTION
change the order of dependencies installation to ensure that `urllib3` is not overwritten

otherwise we have an issue that we do not test `urllib3<2`