### PR TITLE
fix types

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -51,7 +51,7 @@ from urllib.parse import urlunsplit
 
 from urllib3.response import HTTPHeaderDict
 from urllib3.response import HTTPResponse
-from urllib3.util.url import parse_url  # pragma: no cover
+from urllib3.util.url import parse_url
 
 if TYPE_CHECKING:  # pragma: no cover
     # import only for linter run

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -41,21 +41,6 @@ try:
 except ImportError:  # pragma: no cover
     from typing import Literal  # type: ignore  # pragma: no cover
 
-try:
-    from requests.packages.urllib3.response import HTTPResponse
-except ImportError:  # pragma: no cover
-    from urllib3.response import HTTPResponse  # pragma: no cover
-
-try:
-    from requests.packages.urllib3.connection import HTTPHeaderDict
-except ImportError:  # pragma: no cover
-    from urllib3.response import HTTPHeaderDict
-
-try:
-    from requests.packages.urllib3.util.url import parse_url
-except ImportError:  # pragma: no cover
-    from urllib3.util.url import parse_url  # pragma: no cover
-
 from io import BufferedReader
 from io import BytesIO
 from unittest import mock as std_mock
@@ -64,6 +49,10 @@ from urllib.parse import quote
 from urllib.parse import urlsplit
 from urllib.parse import urlunparse
 from urllib.parse import urlunsplit
+
+from urllib3.response import HTTPHeaderDict
+from urllib3.response import HTTPResponse
+from urllib3.util.url import parse_url  # pragma: no cover
 
 if TYPE_CHECKING:  # pragma: no cover
     # import only for linter run
@@ -1096,7 +1085,7 @@ class RequestsMock:
 
         retries = retries or adapter.max_retries
         # first validate that current request is eligible to be retried.
-        # See ``requests.packages.urllib3.util.retry.Retry`` documentation.
+        # See ``urllib3.util.retry.Retry`` documentation.
         if retries.is_retry(
             method=response.request.method, status_code=response.status_code  # type: ignore[misc]
         ):

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qsl
 from urllib.parse import urlparse
 
 from requests import PreparedRequest
-from requests.packages.urllib3.util.url import parse_url
+from urllib3.util.url import parse_url
 
 
 def _create_key_val_str(input_dict: Union[Dict[Any, Any], Any]) -> str:
@@ -256,7 +256,7 @@ def query_string_matcher(query: Optional[str]) -> Callable[..., Any]:
 
     def match(request: PreparedRequest) -> Tuple[bool, str]:
         reason = ""
-        data = parse_url(request.url)
+        data = parse_url(request.url or "")
         request_query = data.query
 
         request_qsl = sorted(parse_qsl(request_query)) if request_query else {}

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1382,15 +1382,13 @@ def test_content_length_error(monkeypatch):
     # Type errors here and on 1250 are ignored because the stubs for requests
     # are off https://github.com/python/typeshed/blob/f8501d33c737482a829c6db557a0be26895c5941
     #   /stubs/requests/requests/packages/__init__.pyi#L1
-    original_init = getattr(requests.packages.urllib3.HTTPResponse, "__init__")  # type: ignore
+    original_init = getattr(urllib3.HTTPResponse, "__init__")  # type: ignore
 
     def patched_init(self, *args, **kwargs):
         kwargs["enforce_content_length"] = True
         original_init(self, *args, **kwargs)
 
-    monkeypatch.setattr(
-        requests.packages.urllib3.HTTPResponse, "__init__", patched_init  # type: ignore
-    )
+    monkeypatch.setattr(urllib3.HTTPResponse, "__init__", patched_init)  # type: ignore
 
     run()
     assert_reset()


### PR DESCRIPTION
* remove dependency on urllib3 vendored in requests since it is not maintained anymore. See https://github.com/python/typeshed/issues/6893#issuecomment-1012511758
* new version of mypy does not require overloads for type checking. `mypy` errors and complains that `overload`  itself has `Any` argument (which is obvious). In theory we can suppress the error with the comment, but at the same time we can just remove overloads as not required. Do not have strong opinion on this.