### PR TITLE
Fix/calllist typing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+0.24.1
+------
+
+* Reintroduced overloads for better typing in `CallList`.
+* Added typing to `Call` attributes.
+
+
 0.24.0
 ------
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -3,7 +3,6 @@ import inspect
 import json as json_module
 import logging
 import socket
-from collections import namedtuple
 from functools import partialmethod
 from functools import wraps
 from http import client
@@ -18,6 +17,7 @@ from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Mapping
+from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Sized
@@ -97,7 +97,11 @@ if TYPE_CHECKING:  # pragma: no cover
     ]
 
 
-Call = namedtuple("Call", ["request", "response"])
+class Call(NamedTuple):
+    request: "PreparedRequest"
+    response: "_Body"
+
+
 _real_send = HTTPAdapter.send
 _UNSET = object()
 

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -24,6 +24,7 @@ from typing import Sized
 from typing import Tuple
 from typing import Type
 from typing import Union
+from typing import overload
 from warnings import warn
 
 import yaml
@@ -240,6 +241,14 @@ class CallList(Sequence[Any], Sized):
 
     def __len__(self) -> int:
         return len(self._calls)
+
+    @overload
+    def __getitem__(self, idx: int) -> Call:
+        ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> List[Call]:
+        ...
 
     def __getitem__(self, idx: Union[int, slice]) -> Union[Call, List[Call]]:
         return self._calls[idx]

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -5,6 +5,7 @@ import warnings
 from io import BufferedReader
 from io import BytesIO
 from typing import Any
+from typing import List
 from typing import Optional
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -20,6 +21,7 @@ from urllib3.util.retry import Retry
 
 import responses
 from responses import BaseResponse
+from responses import Call
 from responses import CallbackResponse
 from responses import PassthroughResponse
 from responses import Response
@@ -2033,6 +2035,37 @@ def test_call_count_without_matcher():
 
     run()
     assert_reset()
+
+
+def test_response_calls_indexing_and_slicing():
+    @responses.activate
+    def run():
+        responses.add(responses.GET, "http://www.example.com")
+        responses.add(responses.GET, "http://www.example.com/1")
+        responses.add(responses.GET, "http://www.example.com/2")
+
+        requests.get("http://www.example.com")
+        requests.get("http://www.example.com/1")
+        requests.get("http://www.example.com/2")
+        requests.get("http://www.example.com/1")
+        requests.get("http://www.example.com")
+
+        # Use of a type hints here ensures mypy knows the difference between index and slice.
+        individual_call: Call = responses.calls[0]
+        call_slice: List[Call] = responses.calls[1:-1]
+
+        assert individual_call.request.url == "http://www.example.com"
+
+        assert call_slice == [
+            responses.calls[1],
+            responses.calls[2],
+            responses.calls[3],
+        ]
+        assert [c.request.url for c in call_slice] == [
+            "http://www.example.com/1",
+            "http://www.example.com/2",
+            "http://www.example.com/1",
+        ]
 
 
 def test_response_calls_and_registry_calls_are_equal():

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class PyTest(TestCommand):
 
 setup(
     name="responses",
-    version="0.24.0",
+    version="0.24.1",
     author="David Cramer",
     description="A utility library for mocking out the `requests` Python library.",
     url="https://github.com/getsentry/responses",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class PyTest(TestCommand):
 
 setup(
     name="responses",
-    version="0.24.1",
+    version="0.24.0",
     author="David Cramer",
     description="A utility library for mocking out the `requests` Python library.",
     url="https://github.com/getsentry/responses",


### PR DESCRIPTION
Typing for the `CallList` class was improved in 0.23.0 (see #593), however this has regressed in 0.24.0 - I believe through the changes made in #684. This PR reintroduces the improved typing from #593.

I've tried to add a test to ensure this doesn't happen again, however it's currently evergreen as `mypy` isn't run on the tests. (IMHO `mypy` - and any other static analysis tools - _should_ be run against the tests. Type hints are great and their use should be encouraged, however by not checking the tests there's nothing checking how these types work from the perspective of the code consuming this package - which is probably how this was missed in #684.)

I did have a brief go at running `mypy` over the tests to give the new test a bit more purpose (and to improve coverage generally), but there were 754 errors so that feels like something that should be addressed in its own PR.

