### PR TITLE
[README] Make "Validate Retry mechanism" code snippet complete

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1232,6 +1232,7 @@ If you are using the ``Retry`` features of ``urllib3`` and want to cover scenari
 
     import responses
     from responses import registries
+    from urllib3.util import Retry
 
 
     @responses.activate(registry=registries.OrderedRegistry)


### PR DESCRIPTION
It was missing the `urllib3.util.Retry` import.