### PR TITLE
fix(matchers): Don't sort failed matches when printing error message

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.25.2
+------
+
+* Fixed error messages when matches fail: inputs are not sorted or reformatted. See #704
+
 0.25.1
 ------
 


### PR DESCRIPTION
Hi!

This PR removes the `_create_key_val_str` and with it the sorting when displaying matchers errors

Let me know any change required!

Thank you 

Fixes GH-704