### PR TITLE
fix mocked HEAD response when content-length header is present

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -532,6 +532,7 @@ def _form_response(
     body: Union[BufferedReader, BytesIO],
     headers: Optional[Mapping[str, str]],
     status: int,
+    request_method: Optional[str],
 ) -> HTTPResponse:
     """
     Function to generate `urllib3.response.HTTPResponse` object.
@@ -566,6 +567,7 @@ def _form_response(
         headers=headers,
         original_response=orig_response,  # type: ignore[arg-type]  # See comment above
         preload_content=False,
+        request_method=request_method,
     )
 
 
@@ -632,7 +634,7 @@ class Response(BaseResponse):
             content_length = len(body.getvalue())
             headers["Content-Length"] = str(content_length)
 
-        return _form_response(body, headers, status)
+        return _form_response(body, headers, status, request.method)
 
     def __repr__(self) -> str:
         return (
@@ -695,7 +697,7 @@ class CallbackResponse(BaseResponse):
         body = _handle_body(body)
         headers.extend(r_headers)
 
-        return _form_response(body, headers, status)
+        return _form_response(body, headers, status, request.method)
 
 
 class PassthroughResponse(BaseResponse):

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -2416,6 +2416,18 @@ class TestShortcuts:
         run()
         assert_reset()
 
+    def test_head_with_content_length(self):
+        @responses.activate
+        def run():
+            headers = {"content-length": "1000"}
+            responses.head("http://example.com/1", status=200, headers=headers)
+            resp = requests.head("http://example.com/1")
+            assert resp.status_code == 200
+            assert resp.headers["Content-Length"] == "1000"
+
+        run()
+        assert_reset()
+
     def test_options(self):
         @responses.activate
         def run():


### PR DESCRIPTION
This PR is a fix for this issue https://github.com/getsentry/responses/issues/708.
Basically when mocking a response to a HEAD request (which contains a content-length header), we do not pass the request_method. Which results in wrongfully raising a `ChunkedEncodingError`