### PR TITLE
Add feature for allowing the body of a request to be matched Closes #716

### DIFF
--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -31,11 +31,26 @@ def _filter_dict_recursively(
     return filtered_dict
 
 
+def body_matcher(params: str, *, allow_blank: bool = False) -> Callable[..., Any]:
+    def match(request: PreparedRequest) -> Tuple[bool, str]:
+        reason = ""
+        if isinstance(request.body, bytes):
+            request_body = request.body.decode("utf-8")
+        else:
+            request_body = request.body
+        valid = True if request_body == params else False
+        if not valid:
+            reason = f"request.body doesn't match {params} doesn't match {request_body}"
+        return valid, reason
+
+    return match
+
+
 def urlencoded_params_matcher(
     params: Optional[Mapping[str, str]], *, allow_blank: bool = False
 ) -> Callable[..., Any]:
     """
-    Matches URL encoded data
+    Matches URL encoded datarequest_body
 
     :param params: (dict) data provided to 'data' arg of request
     :return: (func) matcher
@@ -159,7 +174,8 @@ def query_param_matcher(
         conjunction with ``strict_match=False``.
     strict_match : bool, default=True
         If set to ``True``, validates that all parameters match.
-        If set to ``False``, original request may contain additional parameters.
+        If set to ``False``, original request may contain additional parameters.request_body
+        = request.bodyrequest_body = request.body.decode("utf-8").decode("utf-8")
 
 
     Returns

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -50,7 +50,7 @@ def urlencoded_params_matcher(
     params: Optional[Mapping[str, str]], *, allow_blank: bool = False
 ) -> Callable[..., Any]:
     """
-    Matches URL encoded datarequest_body
+    Matches URL encoded data
 
     :param params: (dict) data provided to 'data' arg of request
     :return: (func) matcher

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -175,7 +175,6 @@ def query_param_matcher(
     strict_match : bool, default=True
         If set to ``True``, validates that all parameters match.
         If set to ``False``, original request may contain additional parameters.request_body
-        = request.bodyrequest_body = request.body.decode("utf-8").decode("utf-8")
 
 
     Returns

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -174,7 +174,7 @@ def query_param_matcher(
         conjunction with ``strict_match=False``.
     strict_match : bool, default=True
         If set to ``True``, validates that all parameters match.
-        If set to ``False``, original request may contain additional parameters.request_body
+        If set to ``False``, original request may contain additional parameters.
 
 
     Returns

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -14,6 +14,40 @@ from responses.tests.test_responses import assert_reset
 from responses.tests.test_responses import assert_response
 
 
+def test_body_match_get():
+    @responses.activate
+    def run():
+        url = "http://example.com"
+        responses.add(
+            responses.GET,
+            url,
+            body=b"test",
+            match=[matchers.body_matcher("123456")],
+        )
+        resp = requests.get("http://example.com", data="123456")
+        assert_response(resp, "test")
+
+    run()
+    assert_reset()
+
+
+def test_body_match_post():
+    @responses.activate
+    def run():
+        url = "http://example.com"
+        responses.add(
+            responses.POST,
+            url,
+            body=b"test",
+            match=[matchers.body_matcher("123456")],
+        )
+        resp = requests.post("http://example.com", data="123456")
+        assert_response(resp, "test")
+
+    run()
+    assert_reset()
+
+
 def test_query_string_matcher():
     @responses.activate
     def run():


### PR DESCRIPTION
I use responses to mock APIs for applications. One of the API's used by my organization is an API for getting identifying information about about the "Owners" of AWS accounts. And the API just takes in the account number as the body of a GET request. 

here is an example of how I query the API from the command line
```
curl api.company.com/v1/accounts --data 12345
```

I have not been able to use responses to mock this API because this data is not JSON. I would like to contribute back a more flexible matcher for the bodies that just lets you match anything sent to an API endpoint. 