### PR TITLE
Add support for drop-in replacement Niquests when installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        requests-version: ['"requests>=2.0,<3.0"']
-        urllib3-version: ['"urllib3<2"', '"urllib3>=2,<3.0"']
-
+        requests-version: ['"requests>=2.0,<3.0"', '"niquests>=3,<4"']
+        urllib3-version: ['"urllib3<2"', '"urllib3>=2,<3.0"', '"urllib3-future>=2,<3"']
+        exclude:
+          - requests-version: '"niquests>=3,<4"'
+            urllib3-version: '"urllib3<2"'
+          - requests-version: '"niquests>=3,<4"'
+            urllib3-version: '"urllib3>=2,<3.0"'
+          - requests-version: '"requests>=2.0,<3.0"'
+            urllib3-version: '"urllib3-future>=2,<3"'
 
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Responses
 .. image:: https://codecov.io/gh/getsentry/responses/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/getsentry/responses/
 
-A utility library for mocking out the ``requests`` Python library.
+A utility library for mocking out the ``requests`` or the ``niquests`` Python library.
 
 ..  note::
 

--- a/responses/_compat.py
+++ b/responses/_compat.py
@@ -1,0 +1,36 @@
+# "responses" was initially made for Requests
+# since the former is in feature freeze, indefinitely
+# alternative started to emerge, like Niquests, which is
+# meant to be a "drop-in" compatible solution.
+# This file is meant to simplify the import logic, whatever the
+# alternative project is.
+
+from os import environ
+
+try:
+    if environ.get("RESPONSES_USE_REQUESTS") is not None:
+        raise ImportError
+
+    import niquests as requests
+    from niquests import PreparedRequest
+    from niquests import models
+    from niquests.adapters import HTTPAdapter
+    from niquests.adapters import MaxRetryError
+    from niquests.exceptions import ChunkedEncodingError
+    from niquests.exceptions import ConnectionError
+    from niquests.exceptions import HTTPError
+    from niquests.exceptions import RetryError
+
+    MOCKED_LIBRARY = "niquests"
+except ImportError:
+    import requests  # noqa: F401
+    from requests import PreparedRequest  # noqa: F401
+    from requests import models  # noqa: F401
+    from requests.adapters import HTTPAdapter  # noqa: F401
+    from requests.adapters import MaxRetryError  # noqa: F401
+    from requests.exceptions import ChunkedEncodingError  # noqa: F401
+    from requests.exceptions import ConnectionError  # noqa: F401
+    from requests.exceptions import HTTPError  # noqa: F401
+    from requests.exceptions import RetryError  # noqa: F401
+
+    MOCKED_LIBRARY = "requests"

--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -27,6 +27,8 @@ from responses import Response
 from responses import _real_send
 from responses.registries import OrderedRegistry
 
+from ._compat import MOCKED_LIBRARY
+
 
 def _remove_nones(d: "Any") -> "Any":
     if isinstance(d, dict):
@@ -94,7 +96,7 @@ class Recorder(RequestsMock):
     def __init__(
         self,
         *,
-        target: str = "requests.adapters.HTTPAdapter.send",
+        target: str = f"{MOCKED_LIBRARY}.adapters.HTTPAdapter.send",
         registry: "Type[FirstMatchRegistry]" = OrderedRegistry,
     ) -> None:
         super().__init__(target=target, registry=registry)

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -14,8 +14,9 @@ from typing import Union
 from urllib.parse import parse_qsl
 from urllib.parse import urlparse
 
-from requests import PreparedRequest
 from urllib3.util.url import parse_url
+
+from ._compat import PreparedRequest
 
 
 def _filter_dict_recursively(

--- a/responses/registries.py
+++ b/responses/registries.py
@@ -6,9 +6,9 @@ from typing import Tuple
 
 if TYPE_CHECKING:  # pragma: no cover
     # import only for linter run
-    from requests import PreparedRequest
-
     from responses import BaseResponse
+
+    from ._compat import PreparedRequest
 
 
 class FirstMatchRegistry:

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -5,13 +5,14 @@ from typing import List
 from unittest.mock import Mock
 
 import pytest
-import requests
-from requests.exceptions import ConnectionError
 
 import responses
 from responses import matchers
 from responses.tests.test_responses import assert_reset
 from responses.tests.test_responses import assert_response
+
+from .._compat import ConnectionError
+from .._compat import requests
 
 
 def test_body_match_get():

--- a/responses/tests/test_multithreading.py
+++ b/responses/tests/test_multithreading.py
@@ -4,9 +4,10 @@ Separate file for multithreading since it takes time to run
 import threading
 
 import pytest
-import requests
 
 import responses
+
+from .._compat import requests
 
 
 @pytest.mark.parametrize("execution_number", range(10))

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 
 import pytest
-import requests
 import tomli_w
 import yaml
 
 import responses
 from responses import _recorder
 from responses._recorder import _dump
+
+from .._compat import requests
 
 try:
     import tomli as _toml

--- a/responses/tests/test_registries.py
+++ b/responses/tests/test_registries.py
@@ -1,11 +1,12 @@
 import pytest
-import requests
-from requests.exceptions import ConnectionError
 
 import responses
 from responses import registries
 from responses.registries import OrderedRegistry
 from responses.tests.test_responses import assert_reset
+
+from .._compat import ConnectionError
+from .._compat import requests
 
 
 def test_set_registry_not_empty():

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = [
 if "test" in sys.argv:
     setup_requires.extend(tests_require)
 
-extras_require = {"tests": tests_require}
+extras_require = {"tests": tests_require, "niquests": ["niquests>=3,<4"]}
 
 
 class PyTest(TestCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py38,py39,py310,py311,py312,mypy,precom
 filterwarnings =
     error
     default::DeprecationWarning
+    ignore:Passing msg:DeprecationWarning
 
 [testenv]
 extras = tests


### PR DESCRIPTION
Close #710 
Close https://github.com/jawah/niquests/issues/109

responses remain attached to Requests indefinitely, but there is an opportunity to support another http client fully compatible with Requests, namely Niquests.

The commit add a thin layer of compat logic to import Niquests instead of Requests if present in the environment. At the time of this commit, Niquests is not likely to be present in one's environment unless that is what the user wanted.

An escape hatch is also present, in case both Niquests and Requests are present and the user wants to mock Requests only. Setting "RESPONSES_USE_REQUESTS" with any value inside revert to using Requests only.

Unfortunately, for the time being, no simple ways emerge to support both library at once.

Comments will be attached to justify every changes. I tried to make it as light as possible.
Of course, if anything started to make your life harder, I will surely come and help as much as I can.

This would offer Niquests users, a reliable way to mock http responses.
Lastly, Niquests does have async via `AsyncSession`, that is a mirror of its synchronous counterpart, and for now, I have no idea how it would be conceivable to support it here. It's not the topic of this PR. Just to brought it up.

regards,