### PR TITLE
recorder: use a case-insensitive HTTP headers check

### DIFF
--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -144,13 +144,20 @@ class Recorder(RequestsMock):
         headers_values = {
             key: value for key, value in requests_response.headers.items()
         }
-        responses_response = Response(
-            method=str(request.method),
-            url=str(requests_response.request.url),
-            status=requests_response.status_code,
-            body=requests_response.text,
-            headers=headers_values,
-        )
+
+        response_params = {
+            "method": str(request.method),
+            "url": str(requests_response.request.url),
+            "status": requests_response.status_code,
+            "body": requests_response.text,
+            "headers": headers_values,
+        }
+
+        # If the header has a content type then pass it in.
+        if content_type := requests_response.headers.get("content-type"):
+            response_params["content_type"] = content_type
+
+        responses_response = Response(**response_params)
         self._registry.add(responses_response)
         return requests_response
 


### PR DESCRIPTION
_recorder._remove_default_headers() does a case-sensitive check for HTTP header field names are case insensitive. The result is that for example, a lower-case 'content-type' field will not be removed. Later, when _add_from_file tries to load the data using RequestsMock.add(), a RuntimeError exception will be raised when it finds the 'content_type' kwarg was passed and 'content-type' is in the 'headers' kwargs.

Fix this by simply having _remove_default_headers() do a case-insensitive check.