### PR TITLE
Fix use of global assert_all_requests_are_fired. Closes #726

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -202,6 +202,8 @@ def get_wrapped(
         Wrapped function
 
     """
+    if assert_all_requests_are_fired is None:
+        assert_all_requests_are_fired = mock.assert_all_requests_are_fired
     assert_mock = std_mock.patch.object(
         target=responses,
         attribute="assert_all_requests_are_fired",
@@ -1014,7 +1016,7 @@ class RequestsMock:
         func: Optional["_F"] = None,
         *,
         registry: Optional[Type[Any]] = None,
-        assert_all_requests_are_fired: bool = False,
+        assert_all_requests_are_fired: bool | None = None,
     ) -> Union[Callable[["_F"], "_F"], "_F"]:
         if func is not None:
             return get_wrapped(func, self)

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1192,6 +1192,25 @@ def test_assert_all_requests_fired_multiple():
     assert_reset()
 
 
+def test_assert_all_requests_fired_global():
+    try:
+        old_value = responses.mock.assert_all_requests_are_fired
+        responses.mock.assert_all_requests_are_fired = True
+
+        @responses.activate
+        def test_some_function():
+            # Not all mocks are called so we'll get an AssertionError
+            responses.add(responses.GET, "http://other_url", json={})
+            responses.add(responses.GET, "http://some_api", json={})
+            requests.get("http://some_api")
+
+        with pytest.raises(AssertionError):
+            test_some_function()
+        assert_reset()
+    finally:
+        responses.mock.assert_all_requests_are_fired = old_value
+
+
 def test_allow_redirects_samehost():
     redirecting_url = "http://example.com"
     final_url_path = "/1"


### PR DESCRIPTION
A somewhat naive fix for the global assert_all_requests_are_fired. Tests are passing locally on 3.12.