### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - run: |
           pip install wheel
           python setup.py bdist_wheel sdist --formats=gztar
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: dist/*


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos