### PR TITLE
Read data from file-like objects in requests (#719)

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1064,7 +1064,8 @@ class RequestsMock:
         # See GH #719
         if isinstance(body, str) or isinstance(body, bytes) or body is None:
             return body
-        # Based on https://github.com/urllib3/urllib3/blob/abbfbcb1dd274fc54b4f0a7785fd04d59b634195/src/urllib3/util/request.py#L220
+        # Based on
+        # https://github.com/urllib3/urllib3/blob/abbfbcb1dd274fc54b4f0a7785fd04d59b634195/src/urllib3/util/request.py#L220
         if hasattr(body, "read"):
             return body.read()  # type: ignore[attr-defined]
         return body  # type: ignore[no-any-return]

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1066,9 +1066,9 @@ class RequestsMock:
             return body
         # Based on
         # https://github.com/urllib3/urllib3/blob/abbfbcb1dd274fc54b4f0a7785fd04d59b634195/src/urllib3/util/request.py#L220
-        if hasattr(body, "read"):
-            return body.read()  # type: ignore[attr-defined]
-        return body  # type: ignore[no-any-return]
+        if hasattr(body, "read") or isinstance(body, BufferedReader):
+            return body.read()
+        return body
 
     def _on_request(
         self,

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1054,6 +1054,21 @@ class RequestsMock:
             params[key] = values
         return params
 
+    def _read_filelike_body(
+        self, body: Union[str, bytes, BufferedReader, None]
+    ) -> Union[str, bytes, None]:
+        # Requests/urllib support multiple types of body, including file-like objects.
+        # Read from the file if it's a file-like object to avoid storing a closed file
+        # in the call list and allow the user to compare against the data that was in the
+        # request.
+        # See GH #719
+        if isinstance(body, str) or isinstance(body, bytes) or body is None:
+            return body
+        # Based on https://github.com/urllib3/urllib3/blob/abbfbcb1dd274fc54b4f0a7785fd04d59b634195/src/urllib3/util/request.py#L220
+        if hasattr(body, "read"):
+            return body.read()  # type: ignore[attr-defined]
+        return body  # type: ignore[no-any-return]
+
     def _on_request(
         self,
         adapter: "HTTPAdapter",
@@ -1067,6 +1082,7 @@ class RequestsMock:
         request.params = self._parse_request_params(request.path_url)  # type: ignore[attr-defined]
         request.req_kwargs = kwargs  # type: ignore[attr-defined]
         request_url = str(request.url)
+        request.body = self._read_filelike_body(request.body)
 
         match, match_failed_reasons = self._find_match(request)
         resp_callback = self.response_callback

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import re
+import tempfile
 import warnings
 from io import BufferedReader
 from io import BytesIO


### PR DESCRIPTION
Fixes #719 

Currently I've only dealt with file-like objects and ignored any of the other types that urllib3 supports (see https://github.com/urllib3/urllib3/blob/abbfbcb1dd274fc54b4f0a7785fd04d59b634195/src/urllib3/util/request.py#L220). This seems like an easy improvement since the alternative is keeping file objects in the call list, which are likely to be closed by the time the user gets to them. I don't know whether `responses` should go further though and try to convert every possible request body into a single format (probably `bytes`) to make it easier for the user to assert on.