### PR TITLE
Add method_or_response= as possible keyword parameter for add() method. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,7 +296,10 @@ Response Parameters
 The following attributes can be passed to a Response mock:
 
 method (``str``)
-    The HTTP method (GET, POST, etc).
+    The HTTP method (GET, POST, etc). You may also use `method_or_response=`
+    as a keyword parameter in place of `method`, in which case all attributes
+    must be passed in as keyword parameters. This is to match the parameter
+    name on the `remove()`, `replace()`, and `upsert ()` methods.
 
 url (``str`` or ``compiled regular expression``)
     The full resource URL.

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -820,7 +820,7 @@ class RequestsMock:
         # must have only one of method or method_or_response
         assert (method is not None and method_or_response is None) or (
             method is None and method_or_response is not None
-        )
+        ), "Only one of `method` or `method_or_response` should be used."
 
         # for backwards compatibility, method takes priority over method_or_response
         actual_method = method if method is not None else method_or_response

--- a/responses/tests/test_responses.py
+++ b/responses/tests/test_responses.py
@@ -74,6 +74,41 @@ def test_response():
     assert_reset()
 
 
+def test_response_using_method_or_response():
+    @responses.activate
+    def run():
+        responses.add(
+            responses.GET, "http://example.net/rest/path/varname", body="return value"
+        )
+        resp = requests.get("http://example.net/rest/path/varname")
+        assert_response(resp, "return value")
+
+        responses.add(
+            method_or_response=responses.GET,
+            url="http://example.net/rest/path/varname",
+            body="return value",
+        )
+        resp = requests.get("http://example.net/rest/path/varname")
+        assert_response(resp, "return value")
+
+        with pytest.raises(AssertionError) as exc:
+            responses.add(
+                method=responses.GET,
+                method_or_response=responses.GET,
+                url="http://example.net/rest/path/varname",
+                body="return value",
+            )
+            resp = requests.get("http://example.net/rest/path/varname")
+            assert_response(resp, "return value")
+        assert (
+            exc.value.args[0]
+            == "Only one of `method` or `method_or_response` should be used."
+        )
+
+    run()
+    assert_reset()
+
+
 def test_response_encoded():
     @responses.activate
     def run():


### PR DESCRIPTION
Fixes issue #734 

Adds a keyword parameter `method_or_response` to the `add(...)` method. The new keyword parameter is added as the last keyword parameter so that existing code that treats the first and second positional arguments as being assigned to the parameters `method` and `url` respectively continues to work without modification. 

Unit test of the new functionality (all tests passing) and documentation in the README.rst have been added. 