### PR TITLE
Support fuller files kwarg for requests.post

### DIFF
--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -4,7 +4,6 @@ import re
 from json.decoder import JSONDecodeError
 from typing import Any
 from typing import Callable
-from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
@@ -16,6 +15,7 @@ from urllib.parse import parse_qsl
 from urllib.parse import urlparse
 
 from requests import PreparedRequest
+from requests.sessions import _Files
 from urllib3.util.url import parse_url
 
 
@@ -274,17 +274,6 @@ def request_kwargs_matcher(kwargs: Optional[Mapping[str, Any]]) -> Callable[...,
         return valid, reason
 
     return match
-
-
-_FileName = Optional[str]
-_FileContent = Union[str, bytes]
-_FileContentType = str
-_FileCustomHeaders = Mapping[str, str]
-_FileSpecTuple2 = tuple[_FileName, _FileContent]
-_FileSpecTuple3 = tuple[_FileName, _FileContent, _FileContentType]
-_FileSpecTuple4 = tuple[_FileName, _FileContent, _FileContentType, _FileCustomHeaders]
-_FileSpec = Union[_FileContent, _FileSpecTuple2, _FileSpecTuple3, _FileSpecTuple4]
-_Files = Union[Mapping[str, _FileSpec], Iterable[tuple[str, _FileSpec]]]
 
 
 def multipart_matcher(

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -4,6 +4,7 @@ import re
 from json.decoder import JSONDecodeError
 from typing import Any
 from typing import Callable
+from typing import Iterable
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
@@ -275,8 +276,19 @@ def request_kwargs_matcher(kwargs: Optional[Mapping[str, Any]]) -> Callable[...,
     return match
 
 
+_FileName = Optional[str]
+_FileContent = Union[str, bytes]
+_FileContentType = str
+_FileCustomHeaders = Mapping[str, str]
+_FileSpecTuple2 = tuple[_FileName, _FileContent]
+_FileSpecTuple3 = tuple[_FileName, _FileContent, _FileContentType]
+_FileSpecTuple4 = tuple[_FileName, _FileContent, _FileContentType, _FileCustomHeaders]
+_FileSpec = Union[_FileContent, _FileSpecTuple2, _FileSpecTuple3, _FileSpecTuple4]
+_Files = Union[Mapping[str, _FileSpec], Iterable[tuple[str, _FileSpec]]]
+
+
 def multipart_matcher(
-    files: Mapping[str, Any], data: Optional[Mapping[str, str]] = None
+    files: _Files, data: Optional[Mapping[str, str]] = None
 ) -> Callable[..., Any]:
     """
     Matcher to match 'multipart/form-data' content-type.


### PR DESCRIPTION
Thanks for taking the time to review this! I ran into this type mismatch with some code that leverages the requests library and was hoping to update responses to match.

---

The `files` keyword argument for the `requests.post` function has this type:

```py
files: _Files | None = ...
```

This commit adds this type alias as found in requests version 2.32.2 and updates this library's `multipart_matcher` function's files keyword argument to be of type `_Files`.