### PR TITLE
Recorder without decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,22 @@ will produce next output:
         status: 202
         url: https://httpstat.us/202
 
+If you are in the REPL, you can also activete the recorder for all following responses:
+
+.. code-block:: python
+
+    import requests
+    from responses import _recorder
+
+    _recorder.recorder.start()
+
+    requests.get("https://httpstat.us/500")
+
+    _recorder.recorder.dump_to_file("out.yaml")
+
+    # you can stop or reset the recorder
+    _recorder.recorder.stop()
+    _recorder.recorder.reset()
 
 Replay responses (populate registry) from files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable
     from typing import Dict
     from typing import List
+    from typing import Optional
     from typing import Type
     from typing import Union
     from responses import FirstMatchRegistry
@@ -122,10 +123,13 @@ class Recorder(RequestsMock):
 
     def dump_to_file(
         self,
-        *,
         file_path: "Union[str, bytes, os.PathLike[Any]]",
-        registered: "List[BaseResponse]",
+        *,
+        registered: "Optional[List[BaseResponse]]" = None,
     ) -> None:
+        """Dump the recorded responses to a file."""
+        if registered is None:
+            registered = self.get_registry().registered
         with open(file_path, "w") as file:
             _dump(registered, file, yaml.dump)
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ filterwarnings =
 [testenv]
 extras = tests
 commands =
-    pytest . --asyncio-mode=auto --cov responses --cov-report term-missing
+    pytest . --asyncio-mode=auto --cov responses --cov-report term-missing {posargs}
 
 
 [testenv:mypy]


### PR DESCRIPTION
I would like to use the recorded in the repl and record my requests.

This adds the code, tests and documentation for this.