### PR TITLE
Remove tests from the wheel and simplify setup.py.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+# Suggest a reasonably modern floor for setuptools to ensure
+# the source dist package is assembled with all the expected resources.
+requires = ["setuptools >= 60", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,7 @@ A utility library for mocking out the `requests` Python library.
 :license: Apache 2.0
 """
 
-import sys
-
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-
-setup_requires = []
 
 install_requires = [
     "requests>=2.30.0,<3.0",
@@ -37,31 +32,11 @@ tests_require = [
     "tomli-w",
 ]
 
-if "test" in sys.argv:
-    setup_requires.extend(tests_require)
-
 extras_require = {"tests": tests_require}
-
-
-class PyTest(TestCommand):
-    """Designed to be run via `python setup.py test`"""
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
-
 
 setup(
     name="responses",
-    version="0.25.3",
+    version="0.25.4",
     author="David Cramer",
     description="A utility library for mocking out the `requests` Python library.",
     url="https://github.com/getsentry/responses",
@@ -72,17 +47,13 @@ setup(
         "Source Code": "https://github.com/getsentry/responses",
     },
     license="Apache 2.0",
-    long_description=open("README.rst").read(),
+    long_description=open("README.rst", encoding="utf-8").read(),
     long_description_content_type="text/x-rst",
     packages=["responses"],
     zip_safe=False,
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require=extras_require,
-    tests_require=tests_require,
-    setup_requires=setup_requires,
-    cmdclass={"test": PyTest},
-    include_package_data=True,
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
Remove the tests/ directory from the wheel distribution of `responses`.  Wheels are intended to be a production release containing no tests.

Update setup.py removing `include_package_data` arg, which causes the wheel to contain the tests. Add a pyproject.toml with setup requires and a build backend. Remove references to the deprecated test command of setup tools.