### PR TITLE
fix #751: add package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=["responses"],
     package_data = {
-        'responses': ['py.typed'],
+        "responses": ["py.typed"],
     },
     zip_safe=False,
     python_requires=">=3.8",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
     long_description=open("README.rst", encoding="utf-8").read(),
     long_description_content_type="text/x-rst",
     packages=["responses"],
+    package_data = {
+        'responses': ['py.typed'],
+    },
     zip_safe=False,
     python_requires=">=3.8",
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     long_description=open("README.rst", encoding="utf-8").read(),
     long_description_content_type="text/x-rst",
     packages=["responses"],
-    package_data = {
+    package_data={
         "responses": ["py.typed"],
     },
     zip_safe=False,


### PR DESCRIPTION
fix #751

In the [PR](https://github.com/getsentry/responses/pull/746) the `include_package_data` flag was removed from `setup.py`.
This caused the `py.typed` marker file to also be removed, resulting in mypy errors:
```
Skipping analyzing "responses": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

Using `package_data` we can pick specific files instead of everything (which was the motive for the latest change).