### PR TITLE
Fix recording content_type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.25.8 (in development)
+0.25.8
 ------
 
 * Fix bug where the content type is always recorded as either text/plain or application/json. See #770

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.25.8 (in development)
+------
+
+* Fix bug where the content type is always recorded as either text/plain or application/json. See #770
+
 0.25.7
 ------
 

--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -26,6 +26,7 @@ import yaml
 from responses import RequestsMock
 from responses import Response
 from responses import _real_send
+from responses import _UNSET
 from responses.registries import OrderedRegistry
 
 
@@ -153,6 +154,7 @@ class Recorder(RequestsMock):
             status=requests_response.status_code,
             body=requests_response.text,
             headers=headers_values,
+            content_type=requests_response.headers.get("Content-Type", _UNSET),
         )
         self._registry.add(responses_response)
         return requests_response

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -58,7 +58,7 @@ def get_data(host, port):
                     "url": f"http://{host}:{port}/202",
                     "body": "OK",
                     "status": 202,
-                    "content_type": "text/plain",
+                    "content_type": "image/tiff",
                     "auto_calculate_content_length": False,
                 }
             },
@@ -132,7 +132,7 @@ class TestRecord:
         httpserver.expect_request("/202").respond_with_data(
             "OK",
             status=202,
-            content_type="text/plain",
+            content_type="image/tiff",
         )
         httpserver.expect_request("/404").respond_with_data(
             "404 Not Found",


### PR DESCRIPTION
The intiial code skipped reorcding the content type and instead fell back to guessing. Now it only falls back to guessing if no explicit content type is provided.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Other

## Description


## Related Issues
- Closes #770


### PR checklist
Before submitting this pull request, I have done the following:
- [x] Read the [contributing guidelines](https://github.com/getsentry/responses?tab=readme-ov-file#contributing)
- [x] Ran `tox` and `pre-commit` checks locally
- [x] Added my changes to the [CHANGES](./../CHANGES) file


## Added/updated tests?
> Current repository has 100% test coverage.

- [x] Yes
- [ ] No, and this is why: <!-- _please replace this line with details on why tests
      have not been included_ -->
- [ ] I need help with writing tests
