### PR TITLE
chore(retry-after): add support for Retry-After header

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -1152,7 +1152,9 @@ class RequestsMock:
         # first validate that current request is eligible to be retried.
         # See ``urllib3.util.retry.Retry`` documentation.
         if retries.is_retry(
-            method=response.request.method, status_code=response.status_code  # type: ignore[misc]
+            method=response.request.method,  # type: ignore[misc]
+            status_code=response.status_code,  # type: ignore[misc]
+            has_retry_after="Retry-After" in response.headers,  # type: ignore[misc]
         ):
             try:
                 retries = retries.increment(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [+] Feature


## Description
Added support for `Retry-After` header which has "special" handling inside `urllib3`


## Related Issues
- Closes #768 


### PR checklist
Before submitting this pull request, I have done the following:
- [-] Read the [contributing guidelines](https://github.com/getsentry/responses?tab=readme-ov-file#contributing)
- [-] Ran `tox` and `pre-commit` checks locally
- [-] Added my changes to the [CHANGES](./../CHANGES) file


## Added/updated tests?
N/A
