### PR TITLE
Fix recorder producing Content-Type in both content_type and headers

### DIFF
--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -145,8 +145,11 @@ class Recorder(RequestsMock):
         request.params = self._parse_request_params(request.path_url)  # type: ignore[attr-defined]
         request.req_kwargs = kwargs  # type: ignore[attr-defined]
         requests_response = _real_send(adapter, request, **kwargs)
+        content_type = requests_response.headers.get("Content-Type", _UNSET)
         headers_values = {
-            key: value for key, value in requests_response.headers.items()
+            key: value
+            for key, value in requests_response.headers.items()
+            if key.lower() != "content-type"
         }
         responses_response = Response(
             method=str(request.method),
@@ -154,7 +157,7 @@ class Recorder(RequestsMock):
             status=requests_response.status_code,
             body=requests_response.text,
             headers=headers_values,
-            content_type=requests_response.headers.get("Content-Type", _UNSET),
+            content_type=content_type,
         )
         self._registry.add(responses_response)
         return requests_response


### PR DESCRIPTION
## Summary

The recorder stores `Content-Type` in both the `content_type` field and the `headers` dict. When the recorded file is loaded via `_add_from_file`, both are passed to `add()`, which raises `RuntimeError("You cannot define both content_type and headers[Content-Type]")`.

The fix excludes `Content-Type` from the `headers` dict when recording, since it's already captured in the dedicated `content_type` field.

## Test plan

- Added `test_recorder_excludes_content_type_from_headers` — records a response with `Content-Type: application/json; charset=UTF-8` and verifies the YAML output has `content_type` set but no `Content-Type` in `headers`
- All 6 recorder tests pass (no regressions)

Fixes #741