### PR TITLE
fix: remove content-type from headers in _add_from_file to avoid RuntimeError

### DIFF
--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -858,12 +858,6 @@ class RequestsMock:
             rsp = rsp["response"]
             headers = rsp["headers"] if "headers" in rsp else None
 
-            # The recorder stores ``content_type`` as a top-level key AND may
-            # also capture a ``content-type`` / ``Content-Type`` entry inside
-            # ``headers``.  Passing both to ``add()`` raises a RuntimeError.
-            # Resolve the conflict by removing the header entry so the
-            # dedicated ``content_type`` kwarg takes precedence, which is the
-            # behaviour recommended by the library.
             if headers is not None and "content_type" in rsp:
                 headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
                 if not headers:

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -856,12 +856,25 @@ class RequestsMock:
 
         for rsp in data["responses"]:
             rsp = rsp["response"]
+            headers = rsp["headers"] if "headers" in rsp else None
+
+            # The recorder stores ``content_type`` as a top-level key AND may
+            # also capture a ``content-type`` / ``Content-Type`` entry inside
+            # ``headers``.  Passing both to ``add()`` raises a RuntimeError.
+            # Resolve the conflict by removing the header entry so the
+            # dedicated ``content_type`` kwarg takes precedence, which is the
+            # behaviour recommended by the library.
+            if headers is not None and "content_type" in rsp:
+                headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+                if not headers:
+                    headers = None
+
             self.add(
                 method=rsp["method"],
                 url=rsp["url"],
                 body=rsp["body"],
                 status=rsp["status"],
-                headers=rsp["headers"] if "headers" in rsp else None,
+                headers=headers,
                 content_type=rsp["content_type"],
                 auto_calculate_content_length=rsp["auto_calculate_content_length"],
             )

--- a/responses/__init__.py
+++ b/responses/__init__.py
@@ -859,7 +859,9 @@ class RequestsMock:
             headers = rsp["headers"] if "headers" in rsp else None
 
             if headers is not None and "content_type" in rsp:
-                headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+                headers = {
+                    k: v for k, v in headers.items() if k.lower() != "content-type"
+                }
                 if not headers:
                     headers = None
 

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -251,6 +251,9 @@ class TestReplay:
         Using mismatched values (``text/html`` in headers vs ``application/json``
         in ``content_type``) ensures the assertion is non-trivial and confirms
         that ``content_type`` takes precedence over the header value.
+
+        The fixture is saved as a ``.yaml`` file so that ``_add_from_file``
+        selects the YAML loader by extension.
         """
         data = {
             "responses": [
@@ -285,12 +288,13 @@ class TestReplay:
             ]
         }
 
-        with open(self.out_file, "w") as f:
+        yaml_file = Path(str(self.out_file) + ".yaml")
+        with open(yaml_file, "w") as f:
             yaml.dump(data, f)
 
         @responses.activate
         def run():
-            responses._add_from_file(file_path=self.out_file)
+            responses._add_from_file(file_path=yaml_file)
 
             # Verify responses were registered without RuntimeError
             assert len(responses.registered()) == 2

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -238,3 +238,63 @@ class TestReplay:
             assert responses.registered()[3].content_type == "text/plain"
 
         run()
+
+    def test_add_from_file_content_type_in_headers(self):
+        """Fixture files may contain Content-Type in both headers and content_type.
+
+        The recorder captures ``Content-Type`` inside the ``headers`` dict *and*
+        as the dedicated ``content_type`` field.  Passing both to ``add()``
+        raises a ``RuntimeError`` because ``content_type`` and a ``Content-Type``
+        header conflict.  ``_add_from_file`` should strip the duplicate header
+        entry so that the dedicated ``content_type`` kwarg wins.
+        """
+        data = {
+            "responses": [
+                {
+                    "response": {
+                        "method": "GET",
+                        "url": "http://example.com/api",
+                        "body": '{"status": "ok"}',
+                        "status": 200,
+                        "headers": {"Content-Type": "application/json"},
+                        "content_type": "application/json",
+                        "auto_calculate_content_length": False,
+                    }
+                },
+                {
+                    "response": {
+                        "method": "POST",
+                        "url": "http://example.com/submit",
+                        "body": "created",
+                        "status": 201,
+                        "headers": {
+                            "Content-Type": "text/plain",
+                            "X-Request-Id": "abc123",
+                        },
+                        "content_type": "text/plain",
+                        "auto_calculate_content_length": False,
+                    }
+                },
+            ]
+        }
+
+        with open(self.out_file, "w") as f:
+            yaml.dump(data, f)
+
+        @responses.activate
+        def run():
+            responses._add_from_file(file_path=self.out_file)
+
+            # Verify responses were registered without RuntimeError
+            assert len(responses.registered()) == 2
+
+            assert responses.registered()[0].url == "http://example.com/api"
+            assert responses.registered()[0].content_type == "application/json"
+
+            assert responses.registered()[1].url == "http://example.com/submit"
+            assert responses.registered()[1].content_type == "text/plain"
+            # Non-content-type headers should be preserved
+            resp = requests.post("http://example.com/submit")
+            assert resp.headers["X-Request-Id"] == "abc123"
+
+        run()

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -190,6 +190,12 @@ class TestReplay:
         if self.out_file.exists():
             self.out_file.unlink()
 
+        # Clean up any extension variants created by individual tests
+        for suffix in (".yaml", ".toml"):
+            p = Path(str(self.out_file) + suffix)
+            if p.exists():
+                p.unlink()
+
         assert not self.out_file.exists()
 
     @pytest.mark.parametrize("parser", (yaml, tomli_w))

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -247,6 +247,10 @@ class TestReplay:
         raises a ``RuntimeError`` because ``content_type`` and a ``Content-Type``
         header conflict.  ``_add_from_file`` should strip the duplicate header
         entry so that the dedicated ``content_type`` kwarg wins.
+
+        Using mismatched values (``text/html`` in headers vs ``application/json``
+        in ``content_type``) ensures the assertion is non-trivial and confirms
+        that ``content_type`` takes precedence over the header value.
         """
         data = {
             "responses": [
@@ -256,7 +260,10 @@ class TestReplay:
                         "url": "http://example.com/api",
                         "body": '{"status": "ok"}',
                         "status": 200,
-                        "headers": {"Content-Type": "application/json"},
+                        # headers has a *different* Content-Type than content_type
+                        # to verify that content_type wins (not just that both happen
+                        # to be the same value).
+                        "headers": {"Content-Type": "text/html"},
                         "content_type": "application/json",
                         "auto_calculate_content_length": False,
                     }
@@ -268,7 +275,7 @@ class TestReplay:
                         "body": "created",
                         "status": 201,
                         "headers": {
-                            "Content-Type": "text/plain",
+                            "Content-Type": "text/html",
                             "X-Request-Id": "abc123",
                         },
                         "content_type": "text/plain",
@@ -288,6 +295,7 @@ class TestReplay:
             # Verify responses were registered without RuntimeError
             assert len(responses.registered()) == 2
 
+            # content_type must win over the conflicting Content-Type header
             assert responses.registered()[0].url == "http://example.com/api"
             assert responses.registered()[0].content_type == "application/json"
 

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -196,6 +196,14 @@ class TestReplay:
             if p.exists():
                 p.unlink()
 
+        # test_add_from_file[tomli_w] monkey-patches responses.mock._parse_response_file
+        # to a TOML loader and never restores it. Reset it here so later tests
+        # don't inherit the TOML parser when they write YAML fixtures.
+        cls = type(responses.mock)
+        responses.mock._parse_response_file = (  # type: ignore[method-assign]
+            cls._parse_response_file.__get__(responses.mock)
+        )
+
         assert not self.out_file.exists()
 
     @pytest.mark.parametrize("parser", (yaml, tomli_w))

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -196,14 +196,6 @@ class TestReplay:
             if p.exists():
                 p.unlink()
 
-        # test_add_from_file[tomli_w] monkey-patches responses.mock._parse_response_file
-        # to a TOML loader and never restores it. Reset it here so later tests
-        # don't inherit the TOML parser when they write YAML fixtures.
-        cls = type(responses.mock)
-        responses.mock._parse_response_file = (  # type: ignore[method-assign]
-            cls._parse_response_file.__get__(responses.mock)
-        )
-
         assert not self.out_file.exists()
 
     @pytest.mark.parametrize("parser", (yaml, tomli_w))
@@ -218,6 +210,8 @@ class TestReplay:
         @responses.activate
         def run():
             responses.patch("http://httpbin.org")
+
+            original_parser = responses.mock._parse_response_file
             if parser == tomli_w:
 
                 def _parse_resp_f(file_path):
@@ -227,29 +221,33 @@ class TestReplay:
 
                 responses.mock._parse_response_file = _parse_resp_f  # type: ignore[method-assign]
 
-            responses._add_from_file(file_path=self.out_file)
-            responses.post("http://httpbin.org/form")
+            try:
+                responses._add_from_file(file_path=self.out_file)
+                responses.post("http://httpbin.org/form")
 
-            assert responses.registered()[0].url == "http://httpbin.org/"
-            assert responses.registered()[1].url == "http://example.com:8080/404"
-            assert (
-                responses.registered()[2].url == "http://example.com:8080/status/wrong"
-            )
-            assert responses.registered()[3].url == "http://example.com:8080/500"
-            assert responses.registered()[4].url == "http://example.com:8080/202"
-            assert responses.registered()[5].url == "http://httpbin.org/form"
+                assert responses.registered()[0].url == "http://httpbin.org/"
+                assert responses.registered()[1].url == "http://example.com:8080/404"
+                assert (
+                    responses.registered()[2].url
+                    == "http://example.com:8080/status/wrong"
+                )
+                assert responses.registered()[3].url == "http://example.com:8080/500"
+                assert responses.registered()[4].url == "http://example.com:8080/202"
+                assert responses.registered()[5].url == "http://httpbin.org/form"
 
-            assert responses.registered()[0].method == "PATCH"
-            assert responses.registered()[2].method == "GET"
-            assert responses.registered()[4].method == "PUT"
-            assert responses.registered()[5].method == "POST"
+                assert responses.registered()[0].method == "PATCH"
+                assert responses.registered()[2].method == "GET"
+                assert responses.registered()[4].method == "PUT"
+                assert responses.registered()[5].method == "POST"
 
-            assert responses.registered()[2].status == 400
-            assert responses.registered()[3].status == 500
+                assert responses.registered()[2].status == 400
+                assert responses.registered()[3].status == 500
 
-            assert responses.registered()[3].body == "500 Internal Server Error"
+                assert responses.registered()[3].body == "500 Internal Server Error"
 
-            assert responses.registered()[3].content_type == "text/plain"
+                assert responses.registered()[3].content_type == "text/plain"
+            finally:
+                responses.mock._parse_response_file = original_parser  # type: ignore[method-assign]
 
         run()
 


### PR DESCRIPTION
## Summary

Fixes #741.

The recorder stores `content_type` as a top-level YAML key **and** may also capture a `content-type` entry inside the `headers` dict (since HTTP servers return `Content-Type` as a response header). When `_add_from_file()` calls `add()` with both `content_type=` and `headers={'content-type': ...}`, it raises:

```
RuntimeError: You cannot define both `content_type` and `headers[Content-Type]`.
Using the `content_type` kwarg is recommended.
```

## Fix

Strip any `content-type` key from `headers` before calling `add()` when `content_type` is also present in the loaded YAML. The `content_type` kwarg takes precedence (already recommended by the library).

```python
if headers is not None and "content_type" in rsp:
    headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
```

This lets recorded YAML files be used in tests without any manual editing.