### PR TITLE
Add strict_match parameter to urlencoded_params_matcher

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@
 * Added Spanish translation of the README (``README.es.rst``)
 * When both `content_type` and `headers['content-type']` are in a response mock file,
   `content_type` is now used.
+* Added strict_match to urlencoded_params_matcher, enabling partial request parameter
+  matching.
 
 0.26.0
 ------

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -47,29 +47,44 @@ def body_matcher(params: str, *, allow_blank: bool = False) -> Callable[..., Any
 
 
 def urlencoded_params_matcher(
-    params: Optional[Mapping[str, str]], *, allow_blank: bool = False
+    params: Optional[Mapping[str, str]],
+    *,
+    allow_blank: bool = False,
+    strict_match: bool = True,
 ) -> Callable[..., Any]:
     """
     Matches URL encoded data
 
     :param params: (dict) data provided to 'data' arg of request
+    :param allow_blank If true, blank values are accounted as empty strings
+    :param strict_match If true, all keys must match;
+        otherwise, partial matches allowed
     :return: (func) matcher
     """
 
     def match(request: PreparedRequest) -> Tuple[bool, str]:
         reason = ""
         request_body = request.body
-        qsl_body = (
+        qsl_body: Mapping[Any, Any] = (
             dict(parse_qsl(request_body, keep_blank_values=allow_blank))  # type: ignore[type-var]
             if request_body
             else {}
         )
         params_dict = params or {}
+
+        if not strict_match:
+            qsl_body = _filter_dict_recursively(qsl_body, params_dict)
+
         valid = params is None if request_body is None else params_dict == qsl_body
         if not valid:
             reason = (
                 f"request.body doesn't match: {qsl_body} doesn't match {params_dict}"
             )
+            if not strict_match:
+                reason += (
+                    "\nNote: You use non-strict parameters check, "
+                    "to change it use `strict_match=True`."
+                )
 
         return valid, reason
 

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -21,6 +21,13 @@ from urllib3.util.url import parse_url
 def _filter_dict_recursively(
     dict1: Mapping[Any, Any], dict2: Mapping[Any, Any]
 ) -> Mapping[Any, Any]:
+    """
+    Make a new dictionary using only keys that exist in both
+    dictionary arguments. It will also work with deeply nested keys.
+    :param dict1: dictionary to filter
+    :param dict2: dictionary to filter
+    :return: new dictionary based on `dict1` and `dict2`
+    """
     filtered_dict = {}
     for k, val in dict1.items():
         if k in dict2:
@@ -70,15 +77,24 @@ def urlencoded_params_matcher(
             if request_body
             else {}
         )
-        params_dict = params or {}
+        request_params = qsl_body
+        match_params = params or {}
 
         if not strict_match:
-            qsl_body = _filter_dict_recursively(qsl_body, params_dict)
+            request_params = _filter_dict_recursively(qsl_body, match_params)
 
-        valid = params is None if request_body is None else params_dict == qsl_body
+        valid = (
+            params is None if request_body is None else match_params == request_params
+        )
+
+        # Prevents non-strict match of empty params with non-empty
+        # request body (due to dictionary filtering)
+        if params is None and request_body is not None:
+            valid = False
+
         if not valid:
             reason = (
-                f"request.body doesn't match: {qsl_body} doesn't match {params_dict}"
+                f"request.body doesn't match: {qsl_body} doesn't match {match_params}"
             )
             if not strict_match:
                 reason += (

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -96,10 +96,10 @@ def urlencoded_params_matcher(
             reason = (
                 f"request.body doesn't match: {qsl_body} doesn't match {match_params}"
             )
-            if not strict_match:
+            if strict_match:
                 reason += (
-                    "\nNote: You use non-strict parameters check, "
-                    "to change it use `strict_match=True`."
+                    "\nNote: You're using strict parameter check. "
+                    "To try a partial match, use strict_match=False"
                 )
 
         return valid, reason

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -89,7 +89,7 @@ def urlencoded_params_matcher(
 
         # Prevents non-strict match of empty params with non-empty
         # request body (due to dictionary filtering)
-        if params is None and request_body is not None:
+        if not params and request_body:
             valid = False
 
         if not valid:

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -243,6 +243,76 @@ def test_urlencoded_params_matcher_blank():
     assert_reset()
 
 
+def test_urlencoded_params_matcher_strict():
+    """Test for partial urlencoded parameter matching"""
+
+    @responses.activate
+    def run():
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="body1",
+            match=[
+                matchers.urlencoded_params_matcher(
+                    {"key1": "value1"}, strict_match=False
+                )
+            ],
+        )
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="body2",
+            match=[
+                matchers.urlencoded_params_matcher(
+                    {"key2": "value2"}, strict_match=False
+                )
+            ],
+        )
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="body3",
+            match=[
+                matchers.urlencoded_params_matcher(
+                    {"key3": "value3"}, strict_match=True  # Note: Strict match
+                )
+            ],
+        )
+
+        resp1 = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={"Content-Type": "x-www-form-urlencoded"},
+            data={"key1": "value1", "type": "urlencoded"},
+        )
+        assert_response(resp1, "body1")
+
+        resp2 = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={"Content-Type": "x-www-form-urlencoded"},
+            data={"key2": "value2", "type": "urlencoded"},
+        )
+        assert_response(resp2, "body2")
+
+        # The third request will NOT match, as it's strict
+        with pytest.raises(ConnectionError) as excinfo:
+            requests.request(
+                "POST",
+                "http://example.com/",
+                headers={"Content-Type": "x-www-form-urlencoded"},
+                data={"key3": "value3", "type": "urlencoded"},
+            )
+        msg = str(excinfo.value)
+        assert (
+            "request.body doesn't match: {'key3': 'value3', 'type': 'urlencoded'} "
+            "doesn't match {'key3': 'value3'}" in msg
+        )
+
+    run()
+    assert_reset()
+
+
 def test_query_params_numbers():
     @responses.activate
     def run():

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -284,7 +284,7 @@ def test_urlencoded_params_matcher_strict():
             method=responses.POST,
             url="http://example.com/",
             body="body4",
-            match=[matchers.urlencoded_params_matcher(None, strict_match=False)],
+            match=[matchers.urlencoded_params_matcher({}, strict_match=False)],
         )
         # Test for successful strict matching:
         responses.add(

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -268,6 +268,7 @@ def test_urlencoded_params_matcher_strict():
                 )
             ],
         )
+        # Fail for insufficient params and strict matching:
         responses.add(
             method=responses.POST,
             url="http://example.com/",
@@ -277,6 +278,13 @@ def test_urlencoded_params_matcher_strict():
                     {"key3": "value3"}, strict_match=True  # Note: Strict match
                 )
             ],
+        )
+        # Fail for non-strict matching of empty params with non-empty body:
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="body4",
+            match=[matchers.urlencoded_params_matcher(None, strict_match=False)],
         )
 
         resp1 = requests.request(
@@ -295,7 +303,7 @@ def test_urlencoded_params_matcher_strict():
         )
         assert_response(resp2, "body2")
 
-        # The third request will NOT match, as it's strict
+        # The third request should NOT match, as it's strict
         with pytest.raises(ConnectionError) as excinfo:
             requests.request(
                 "POST",
@@ -307,6 +315,20 @@ def test_urlencoded_params_matcher_strict():
         assert (
             "request.body doesn't match: {'key3': 'value3', 'type': 'urlencoded'} "
             "doesn't match {'key3': 'value3'}" in msg
+        )
+
+        # The fourth request should NOT match with empty params
+        with pytest.raises(ConnectionError) as excinfo:
+            requests.request(
+                "POST",
+                "http://example.com/",
+                headers={"Content-Type": "x-www-form-urlencoded"},
+                data={"key4": "value4", "type": "urlencoded"},
+            )
+        msg = str(excinfo.value)
+        assert (
+            "request.body doesn't match: {'key4': 'value4', 'type': 'urlencoded'} "
+            "doesn't match {}" in msg
         )
 
     run()

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -286,6 +286,17 @@ def test_urlencoded_params_matcher_strict():
             body="body4",
             match=[matchers.urlencoded_params_matcher(None, strict_match=False)],
         )
+        # Test for successful strict matching:
+        responses.add(
+            method=responses.POST,
+            url="http://example.com/",
+            body="body5",
+            match=[
+                matchers.urlencoded_params_matcher(
+                    {"key5": "value5", "type": "urlencoded"}, strict_match=True
+                )
+            ],
+        )
 
         resp1 = requests.request(
             "POST",
@@ -330,6 +341,14 @@ def test_urlencoded_params_matcher_strict():
             "request.body doesn't match: {'key4': 'value4', 'type': 'urlencoded'} "
             "doesn't match {}" in msg
         )
+
+        resp5 = requests.request(
+            "POST",
+            "http://example.com/",
+            headers={"Content-Type": "x-www-form-urlencoded"},
+            data={"key5": "value5", "type": "urlencoded"},
+        )
+        assert_response(resp5, "body5")
 
     run()
     assert_reset()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Other

## Description
Adds the `strict_match` parameter to `urlencoded_params_matcher`, enabling partial matching of request parameters. The JSON and query matchers, for example, already have this feature.

## Related Issues
<!-- Add many as needed, one per line. -->
- Closes #792 


### PR checklist
Before submitting this pull request, I have done the following:
- [x] Read the [contributing guidelines](https://github.com/getsentry/responses?tab=readme-ov-file#contributing)
- [x] Ran `tox` and `pre-commit` checks locally
- [x] Added my changes to the [CHANGES](./../CHANGES) file


## Added/updated tests?
> Current repository has 100% test coverage.

- [x] Yes
- [ ] No, and this is why: <!-- _please replace this line with details on why tests
      have not been included_ -->
- [ ] I need help with writing tests
