### PR TITLE
docs: update tox Python version examples

### DIFF
--- a/README.es.rst
+++ b/README.es.rst
@@ -1513,7 +1513,7 @@ Puedes ejecutar todas las pruebas con:
 
 .. code-block:: shell
 
-    tox -e py37
+    tox -e py38
     tox -e py310
 
 O activando manualmente la versión de Python requerida y ejecutando:

--- a/README.rst
+++ b/README.rst
@@ -1500,7 +1500,7 @@ testing. You can run all tests by:
 
 .. code-block:: shell
 
-    tox -e py37
+    tox -e py38
     tox -e py310
 
 OR manually activate required version of Python and run


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Other

## Description

The testing section still showed `tox -e py37`, but Python 3.7 support has been removed. This updates the English and Spanish README examples to use `py38`, matching the current `tox.ini` env list and `python_requires >=3.8` package metadata.

## Related Issues

None.

### PR checklist
Before submitting this pull request, I have done the following:
- [x] Read the contributing guidelines
- [x] Ran relevant local checks
- [ ] Added my changes to the CHANGES file

## Added/updated tests?
> Current repository has 100% test coverage.

- [ ] Yes
- [x] No, docs-only example update.
- [ ] I need help with writing tests

Checked:
- `tox list`
- `tox -e py37 --notest`
- `python setup.py check --metadata --restructuredtext`
- `python -m pytest . --asyncio-mode=auto`
- `pre-commit run --all-files`
- `PIP_CONSTRAINT=/tmp/responses-constraints.txt tox -r -e py39`
- `git diff --check`

Note: unconstrained `tox -e py39` hit urllib3's `NotOpenSSLWarning` on Apple's LibreSSL-backed Python 3.9 before tests were collected. The constrained tox run used `urllib3<2`, which is still inside the package's declared dependency range, and passed.
