### PR TITLE
Strip default headers from recorded files case-insensitively

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,10 @@
   `content_type` is now used.
 * Added strict_match to urlencoded_params_matcher, enabling partial request parameter
   matching.
+* Default headers (such as ``Content-Type``, ``Date`` and ``Server``) are now stripped
+  from recorded files regardless of header name case. Previously, responses recorded from
+  servers that send lowercase header names (for example over HTTP/2) kept these redundant
+  headers in the generated file.
 
 0.26.0
 ------

--- a/responses/_recorder.py
+++ b/responses/_recorder.py
@@ -52,11 +52,15 @@ def _remove_default_headers(data: "Any") -> "Any":
             "Connection",
             "Content-Encoding",
         ]
+        # HTTP header names are case-insensitive, and HTTP/2 servers send them
+        # lowercase, so match without regard to case.
+        keys_to_remove_lower = {key.lower() for key in keys_to_remove}
         for i, response in enumerate(data["responses"]):
-            for key in keys_to_remove:
-                if key in response["response"]["headers"]:
-                    del data["responses"][i]["response"]["headers"][key]
-            if not response["response"]["headers"]:
+            headers = data["responses"][i]["response"]["headers"]
+            for key in list(headers):
+                if key.lower() in keys_to_remove_lower:
+                    del headers[key]
+            if not headers:
                 del data["responses"][i]["response"]["headers"]
     return data
 

--- a/responses/tests/test_recorder.py
+++ b/responses/tests/test_recorder.py
@@ -8,6 +8,7 @@ import yaml
 import responses
 from responses import _recorder
 from responses._recorder import _dump
+from responses._recorder import _remove_default_headers
 
 try:
     import tomli as _toml
@@ -65,6 +66,44 @@ def get_data(host, port):
         ]
     }
     return data
+
+
+def test_remove_default_headers_is_case_insensitive():
+    """Default headers should be stripped regardless of their case.
+
+    HTTP/2 servers send header names in lowercase, so the recorded file may
+    contain e.g. ``content-type`` / ``date`` rather than ``Content-Type`` /
+    ``Date``. These still need to be removed, otherwise the recorded file
+    keeps verbose default headers (and, for content-type, a value that is
+    already stored in the ``content_type`` field).
+    """
+    data = {
+        "responses": [
+            {
+                "response": {
+                    # mixed lower/title/upper case to pin the case-insensitive contract
+                    "headers": {
+                        "content-type": "application/json",
+                        "Date": "Mon, 01 Jan 2024 00:00:00 GMT",
+                        "SERVER": "nginx",
+                        "x-custom": "keep-me",
+                    }
+                }
+            },
+            {
+                # a response whose headers are all default ones is left without a
+                # "headers" key at all
+                "response": {
+                    "headers": {"content-length": "12", "connection": "keep-alive"}
+                }
+            },
+        ]
+    }
+
+    result = _remove_default_headers(data)
+
+    assert result["responses"][0]["response"]["headers"] == {"x-custom": "keep-me"}
+    assert "headers" not in result["responses"][1]["response"]
 
 
 class TestRecord:


### PR DESCRIPTION
## Problem

`responses._recorder._remove_default_headers` strips noise headers (`Content-Type`, `Content-Length`, `Date`, `Server`, `Connection`, `Content-Encoding`) from recorded fixture files so they are not stored verbosely.

It matched header names by exact case. HTTP header names are case-insensitive, and HTTP/2 servers send them lowercase (`content-type`, `date`, ...). When a response was recorded from such a server, these default headers were not stripped and stayed in the generated file.

For `content-type` specifically this also duplicated information that is already stored in the `content_type` field. The replay-side RuntimeError this used to cause was fixed in #791 (the loader now drops a duplicate content-type); this change fixes the recording side so the file is clean in the first place.

## Fix

Match the default header names without regard to case: lowercase the removal list once, then drop any recorded header whose name matches case-insensitively.

## Tests

Added `test_remove_default_headers_is_case_insensitive`, covering mixed lower/title/upper-case default headers (a non-default header is preserved) and a response whose headers are all defaults (the `headers` key is removed entirely).

Verified locally: new test fails without the change and passes with it; the full `responses/tests/` suite passes (226 passed); `ruff check` and `ruff format` are clean.