### PR TITLE
docs: fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1401,7 +1401,7 @@ will produce next output:
         status: 202
         url: https://httpstat.us/202
 
-If you are in the REPL, you can also activete the recorder for all following responses:
+If you are in the REPL, you can also activate the recorder for all following responses:
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check