### PR TITLE
fix: query_param_matcher no longer mutates the caller's params dict

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
   from recorded files regardless of header name case. Previously, responses recorded from
   servers that send lowercase header names (for example over HTTP/2) kept these redundant
   headers in the generated file.
+* Fixed `query_param_matcher` mutating the caller's params dict when numeric
+  values are provided. See #801
 
 0.26.0
 ------

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -215,7 +215,7 @@ def query_param_matcher(
 
     """
 
-    params_dict = params or {}
+    params_dict = dict(params) if params else {}
 
     for k, v in params_dict.items():
         if isinstance(v, (int, float)):

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -371,6 +371,24 @@ def test_query_params_numbers():
     assert_reset()
 
 
+def test_query_param_matcher_does_not_mutate_input():
+    """query_param_matcher must not modify the caller's params dict.
+
+    Numeric values (int/float) are converted to strings internally for
+    comparison, but the conversion must not happen on the original dict.
+    """
+    params = {"page": 1, "ratio": 0.5, "name": "test"}
+    original_types = {k: type(v) for k, v in params.items()}
+
+    matchers.query_param_matcher(params)
+
+    for k, expected_type in original_types.items():
+        assert type(params[k]) is expected_type, (
+            f"query_param_matcher mutated params[{k!r}]: "
+            f"expected {expected_type.__name__}, got {type(params[k]).__name__}"
+        )
+
+
 def test_query_param_matcher_empty_value():
     @responses.activate
     def run():


### PR DESCRIPTION
## Problem

`query_param_matcher` converts `int` and `float` values to strings so they can
be compared against URL query-string values (which are always strings). However,
this conversion was done in-place on the dict reference obtained via
`params_dict = params or {}`, which aliases the original dict when a non-empty
mapping is passed. As a result, every numeric value in the caller's dict is
silently overwritten with its string equivalent:

```python
params = {"page": 1, "ratio": 0.5}
matchers.query_param_matcher(params)
# params is now {"page": "1", "ratio": "0.5"} — mutated!
```

This is surprising behaviour that can cause hard-to-debug failures when the
same dict is inspected or reused after the matcher is created.

## Fix

Copy the mapping into a fresh dict before the normalisation loop:

```python
-    params_dict = params or {}
+    params_dict = dict(params) if params else {}
```

A regression test (`test_query_param_matcher_does_not_mutate_input`) is
included.

This pull request was prepared with the assistance of AI, under my direction and review.