### PR TITLE
Set license format to SPDX identifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "Documentation": "https://github.com/getsentry/responses/blob/master/README.rst",
         "Source Code": "https://github.com/getsentry/responses",
     },
-    license="Apache 2.0",
+    license="Apache-2.0",
     long_description=open("README.rst", encoding="utf-8").read(),
     long_description_content_type="text/x-rst",
     packages=["responses"],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Other

## Description
Right now the License uses `Apache 2.0` instead of the SPDX compliant `Apache-2.0`.

This causes problems with some license scanners like https://github.com/anchore/grant

### PR checklist
Before submitting this pull request, I have done the following:
- [x] Read the [contributing guidelines](https://github.com/getsentry/responses?tab=readme-ov-file#contributing)
- [x] Ran `tox` and `pre-commit` checks locally
- [] Added my changes to the [CHANGES](./../CHANGES) file

Don't think it's relevant enough for CHANGES.


## Added/updated tests?
> Current repository has 100% test coverage.

- [ ] Yes
- [x ] No, and this is why: Documentation Change
- [ ] I need help with writing tests
