### PR TITLE
fix: keep blank-valued query params significant in query_string_matcher

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+0.26.3
+------
+
+* Fixed `query_string_matcher` (and the query matching auto-applied to a
+  registered URL's own query string) discarding blank-valued query params
+  (``b=``), which caused requests with an extra or missing blank param to
+  match incorrectly. See #804
+
 0.26.2
 ------
 

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -259,8 +259,12 @@ def query_string_matcher(query: Optional[str]) -> Callable[..., Any]:
         data = parse_url(request.url or "")
         request_query = data.query
 
-        request_qsl = sorted(parse_qsl(request_query)) if request_query else {}
-        matcher_qsl = sorted(parse_qsl(query)) if query else {}
+        request_qsl = (
+            sorted(parse_qsl(request_query, keep_blank_values=True))
+            if request_query
+            else {}
+        )
+        matcher_qsl = sorted(parse_qsl(query, keep_blank_values=True)) if query else {}
 
         valid = not query if request_query is None else request_qsl == matcher_qsl
 

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -69,6 +69,40 @@ def test_query_string_matcher():
     assert_reset()
 
 
+def test_query_string_matcher_blank_values():
+    """A blank-valued query param (``foo=``) is significant: it must be present
+    to match, and an extra blank param must not be ignored."""
+
+    def run():
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(
+                responses.GET,
+                "http://example.com",
+                body=b"test",
+                match=[matchers.query_string_matcher("test=1&foo=")],
+            )
+            # Exact match, including the blank param, succeeds.
+            resp = requests.get("http://example.com?test=1&foo=")
+            assert_response(resp, "test")
+            # Omitting the required blank param must not match.
+            with pytest.raises(ConnectionError):
+                requests.get("http://example.com?test=1")
+
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(
+                responses.GET,
+                "http://example.com",
+                body=b"test",
+                match=[matchers.query_string_matcher("test=1")],
+            )
+            # An extra blank param must not be silently ignored.
+            with pytest.raises(ConnectionError):
+                requests.get("http://example.com?test=1&foo=")
+
+    run()
+    assert_reset()
+
+
 def test_request_matches_post_params():
     @responses.activate
     def run(deprecated):


### PR DESCRIPTION
`query_string_matcher` parses both the incoming request query and the configured query with `parse_qsl()` at its default `keep_blank_values=False`, so any empty-valued parameter (`b=`, or a bare `b`) is dropped before comparison:

```python
>>> parse_qsl("a=1&b=")
[('a', '1')]          # b= vanished
```

This matcher is auto-added for any registered URL carrying a query string (`BaseResponse._should_match_querystring`), so blank params are silently ignored on both sides of the default path:

```python
responses.add(responses.GET, "http://example.com/?a=1", body="M")
requests.get("http://example.com/?a=1&b=")   # wrongly matches (the extra b= is ignored)
```

It's also inconsistent with the request-param parser in `responses/__init__.py`, which uses `keep_blank_values=True` — so `request.params` and the explicit `query_param_matcher` already treat `b=` as a real parameter.

**Fix:** parse both sides of `query_string_matcher` with `keep_blank_values=True`. Added `test_query_string_matcher_blank_values` (fails on `master`, passes with this change).

---
*Disclosure: fully AI-authored (Claude Code, autonomous) — an AI wrote the change and ran the tests; the account operator did not hand-review the diff.*
