### PR TITLE
Match header field names case-insensitively in the default header_matcher

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,10 @@
   registered URL's own query string) discarding blank-valued query params
   (``b=``), which caused requests with an extra or missing blank param to
   match incorrectly. See #804
+* Fixed the default `header_matcher` (``strict_match=False``) matching header
+  field names case-sensitively, so a request whose header casing differed from
+  the matcher spec (for example lowercase names over HTTP/2) failed to match.
+  See #805
 
 0.26.2
 ------

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -432,8 +432,12 @@ def header_matcher(
         request_headers: Union[Mapping[Any, Any], Any] = request.headers or {}
 
         if not strict_match:
-            # filter down to just the headers specified in the matcher
-            request_headers = {k: v for k, v in request_headers.items() if k in headers}
+            # Filter to the matcher's headers, keyed by the matcher's names, so
+            # the case-insensitive lookup on request.headers (a
+            # CaseInsensitiveDict) is not lost in the plain-dict rebuild.
+            request_headers = {
+                k: request_headers[k] for k in headers if k in request_headers
+            }
 
         valid = _compare_with_regex(request_headers)
 

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -857,6 +857,26 @@ def test_request_matches_headers():
     assert_reset()
 
 
+def test_request_matches_headers_case_insensitive_field_names():
+    # HTTP header names are case-insensitive (and HTTP/2 lower-cases them), so
+    # the default matcher must match regardless of the field-name casing.
+    @responses.activate
+    def run():
+        url = "http://example.com/"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json={"success": True},
+            match=[matchers.header_matcher({"X-Custom": "token"})],
+        )
+
+        resp = requests.get(url, headers={"x-custom": "token"})
+        assert_response(resp, body='{"success": true}', content_type="application/json")
+
+    run()
+    assert_reset()
+
+
 def test_request_header_value_mismatch_raises():
     @responses.activate
     def run():


### PR DESCRIPTION
HTTP header field names are case-insensitive, and `requests` stores `request.headers` as a `CaseInsensitiveDict`. But the default `header_matcher` (`strict_match=False`) rebuilds them into a plain dict keyed by the request's original casing, filtered with a case-sensitive `k in headers`:

```python
request_headers = {k: v for k, v in request_headers.items() if k in headers}
```

So any casing difference drops the header and the match fails — with a misleading `{} doesn't match` reason:

```python
matchers.header_matcher({"X-Custom": "foo"})   # request sends "x-custom: foo"
# -> (False, "Headers do not match: {} doesn't match {'X-Custom': 'foo'}")
```

`strict_match=True` keeps the `CaseInsensitiveDict` and already matches case-insensitively, so the default path was the odd one out. It matters in practice because HTTP/2 mandates lowercase header names, so client code (or a recorded cassette) can easily send `content-type` where the matcher spec writes `Content-Type`.

The fix keys the filtered dict by the matcher's names, using `CaseInsensitiveDict` membership so the case-insensitive lookup survives. Value comparisons, missing-header detection, and `strict_match=True` are unchanged; the full suite stays green.

Disclosure: found and written by an AI coding agent (Claude Code) running autonomously on this account; the human account holder reviews every change and is accountable for it. The verification is real and re-runnable from the diff.

