### PR TITLE
fix: compare opaque fragment identifiers verbatim

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@
   registered URL's own query string) discarding blank-valued query params
   (``b=``), which caused requests with an extra or missing blank param to
   match incorrectly. See #804
+* Fixed `fragment_identifier_matcher` treating opaque fragments (those without
+  ``=``, e.g. ``/users/5``) as always equal, so a required fragment matched a
+  different one or none at all. See #806
 
 0.26.2
 ------

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -176,9 +176,16 @@ def fragment_identifier_matcher(identifier: Optional[str]) -> Callable[..., Any]
         reason = ""
         url_fragment = urlparse(request.url).fragment
         if identifier:
-            url_fragment_qsl = sorted(parse_qsl(url_fragment))  # type: ignore[type-var]
-            identifier_qsl = sorted(parse_qsl(identifier))
-            valid = identifier_qsl == url_fragment_qsl
+            if "=" in identifier:
+                # Query-string-style fragment: compare order-insensitively.
+                url_fragment_qsl = sorted(parse_qsl(url_fragment))  # type: ignore[type-var]
+                identifier_qsl = sorted(parse_qsl(identifier))
+                valid = identifier_qsl == url_fragment_qsl
+            else:
+                # Opaque fragment (e.g. "/users/5"): parse_qsl() yields no
+                # pairs, so any two opaque fragments would compare equal.
+                # Compare them verbatim instead.
+                valid = identifier == url_fragment
         else:
             valid = not url_fragment
 

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -974,6 +974,37 @@ def test_fragment_identifier_matcher():
     assert_reset()
 
 
+def test_fragment_identifier_matcher_opaque():
+    """Opaque (non key=value) fragments must compare verbatim.
+
+    Previously ``parse_qsl`` reduced any opaque fragment to ``[]``, so a
+    required ``#/users/5`` matched any other opaque fragment (or none).
+    """
+
+    @responses.activate
+    def run():
+        responses.add(
+            responses.GET,
+            "http://example.com/",
+            match=[matchers.fragment_identifier_matcher("/users/5")],
+            body=b"test",
+        )
+
+        # A different opaque fragment, or no fragment, must not match.
+        with pytest.raises(ConnectionError) as excinfo:
+            requests.get("http://example.com/#/users/6")
+        assert (
+            "URL fragment identifier is different: /users/5 doesn't match /users/6"
+        ) in str(excinfo.value)
+
+        # The exact opaque fragment matches.
+        resp = requests.get("http://example.com/#/users/5")
+        assert_response(resp, "test")
+
+    run()
+    assert_reset()
+
+
 def test_fragment_identifier_matcher_error():
     @responses.activate
     def run():


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

`fragment_identifier_matcher` ran both the required identifier and the request
URL fragment through `parse_qsl`. For an opaque fragment such as `/users/5`
(no `=`), `parse_qsl` returns `[]`, so any two opaque fragments — or a request
with no fragment at all — compared equal. A matcher registered for `#/users/5`
therefore also matched `#/users/6`, `#section2`, and URLs with no fragment.

This only runs the order-insensitive `parse_qsl` comparison when the identifier
is query-string-style (contains `=`); otherwise it compares the fragment
strings verbatim. Key=value fragments are unaffected.

## Related Issues

None.

### PR checklist

- [x] Read the contributing guidelines
- [x] Ran the matcher tests and `black` / `isort` / `flake8` locally (all clean)
- [x] Added an entry to the CHANGES file

## Added/updated tests?

- [x] Yes — `test_fragment_identifier_matcher_opaque` fails on `main` (the
  matcher accepts `#/users/6`) and passes with this change; the full
  `test_matchers.py` suite stays green.

---

Disclosure: this change was authored by an AI coding agent (Claude Code) on this
account — it found the bug, reproduced it against `main`, wrote the failing test
first, and confirmed key=value fragments are unaffected. The account holder
reviews every change and is accountable for it. Happy to close if it's not
wanted.
