### PR TITLE
Handle nested JSON type mismatches in non-strict matcher

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
 * Fixed `fragment_identifier_matcher` treating opaque fragments (those without
   ``=``, e.g. ``/users/5``) as always equal, so a required fragment matched a
   different one or none at all. See #806
+* Fixed non-strict `json_params_matcher` raising `TypeError` when an actual
+  nested object is compared with an expected scalar value.
 
 0.26.2
 ------

--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -31,7 +31,7 @@ def _filter_dict_recursively(
     filtered_dict = {}
     for k, val in dict1.items():
         if k in dict2:
-            if isinstance(val, dict):
+            if isinstance(val, dict) and isinstance(dict2[k], dict):
                 val = _filter_dict_recursively(val, dict2[k])
             filtered_dict[k] = val
 

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -210,6 +210,25 @@ def test_json_params_matcher_not_strict_diff_values():
     assert_reset()
 
 
+def test_json_params_matcher_not_strict_nested_type_mismatch():
+    mock_request = Mock(body='{"page": {"type": "json"}}')
+
+    result = matchers.json_params_matcher(
+        {"page": 1},
+        strict_match=False,
+    )(mock_request)
+
+    assert result == (
+        False,
+        (
+            "request.body doesn't match: {'page': {'type': 'json'}} "
+            "doesn't match {'page': 1}\n"
+            "Note: You use non-strict parameters check, "
+            "to change it use `strict_match=True`."
+        ),
+    )
+
+
 def test_failed_matchers_dont_modify_inputs_order_in_error_message():
     json_a = {"array": ["C", "B", "A"]}
     json_b = '{"array" : ["B", "A", "C"]}'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update

## Description

In non-strict mode, `json_params_matcher` currently raises `TypeError` when the actual value at a matched key is a nested object but the expected value is a scalar. `_filter_dict_recursively` assumes the expected value is also a dictionary before recursing.

This change only recurses when both sides are dictionaries. The resulting filtered value then goes through the matcher's normal comparison path and produces a useful mismatch reason.

## Related Tickets & Documents

Fixes #814

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

The regression test covers an actual nested object compared with an expected scalar in non-strict mode.

Local verification:

- `pytest responses/tests/test_matchers.py -q` — 43 passed
- The broader suite reached 218 passed; 12 tests could not start because `pytest-httpserver` was unavailable in the local environment.
- `git diff --check`

## Updated CHANGES?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why CHANGES have not been updated_

## Are there any post deployment tasks we need to perform?

None.

## AI assistance disclosure

OpenAI Codex (GPT-5) assisted with investigation, the reproducer, regression test, implementation, and drafting this PR. I reviewed the diff and ran the checks listed above locally.