### PR TITLE
Fix json_params_matcher raising TypeError on nested vs scalar mismatch (#814)

### DIFF
--- a/responses/matchers.py
+++ b/responses/matchers.py
@@ -31,7 +31,7 @@ def _filter_dict_recursively(
     filtered_dict = {}
     for k, val in dict1.items():
         if k in dict2:
-            if isinstance(val, dict):
+            if isinstance(val, dict) and isinstance(dict2[k], dict):
                 val = _filter_dict_recursively(val, dict2[k])
             filtered_dict[k] = val
 

--- a/responses/tests/test_matchers.py
+++ b/responses/tests/test_matchers.py
@@ -210,6 +210,23 @@ def test_json_params_matcher_not_strict_diff_values():
     assert_reset()
 
 
+def test_json_params_matcher_not_strict_scalar_vs_nested_does_not_raise():
+    # Regression test for #814: a non-strict match where the expected value is a
+    # scalar but the actual value is a nested dict used to raise
+    # `TypeError: argument of type 'int' is not iterable` instead of reporting a
+    # normal mismatch. The matcher should return (False, reason) in both the
+    # scalar-vs-nested and nested-vs-scalar directions.
+    matcher = matchers.json_params_matcher({"page": 1}, strict_match=False)
+    result = matcher(Mock(body='{"page": {"type": "json"}}'))
+    assert result[0] is False
+
+    matcher = matchers.json_params_matcher(
+        {"page": {"type": "json"}}, strict_match=False
+    )
+    result = matcher(Mock(body='{"page": 1}'))
+    assert result[0] is False
+
+
 def test_failed_matchers_dont_modify_inputs_order_in_error_message():
     json_a = {"array": ["C", "B", "A"]}
     json_b = '{"array" : ["B", "A", "C"]}'


### PR DESCRIPTION
## Summary
Fixes #814. `json_params_matcher` with `strict_match=False` raised `TypeError: argument of type 'int' is not iterable` (instead of reporting a normal mismatch) when the expected params had a scalar at a key but the actual JSON body had a nested object at the same key (and vice versa).

## Root cause
`responses/matchers.py::_filter_dict_recursively` recursed whenever the value in the first dict was a mapping, without checking that the corresponding value in the second dict was also a mapping. The recursive call then did `key in <scalar>`, which raised.

## Fix
Recurse only when **both** values are mappings:
```python
if isinstance(val, dict) and isinstance(dict2[k], dict):
    val = _filter_dict_recursively(val, dict2[k])
```
A type mismatch at a key is now reported as a normal non-match `(False, reason)` instead of crashing.

## Test
- Added `test_json_params_matcher_not_strict_scalar_vs_nested_does_not_raise` in `responses/tests/test_matchers.py`, asserting the matcher returns `(False, ...)` (not raises) in both the scalar-vs-nested and nested-vs-scalar directions.
- Full suite: 230 passed; flake8/black/isort clean.